### PR TITLE
Feat/local infra postgres redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+!.env.*.example
 !*.env.example
 *.pem
 *.key

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ The complete design is documented in [specs/](specs), including architecture, AP
 - [specs/api-contracts.md](specs/api-contracts.md)
 - [specs/frontend-spec.md](specs/frontend-spec.md)
 
+## Local Infrastructure Startup
+
+Core local dependencies (PostgreSQL + Redis) and platform services are orchestrated with Docker Compose:
+
+```bash
+docker compose -f infra/docker-compose.local.yml up -d
+```
+
+Quick checks:
+
+- Gateway health: `http://localhost:8000/health`
+- Wallet health via gateway: `http://localhost:8000/v1/wallet/health`
+
+Shutdown:
+
+```bash
+docker compose -f infra/docker-compose.local.yml down
+```
+
 ## Environment Profiles and Secrets
 
 Python services share a centralized settings module at `services/common/config.py`.
@@ -36,6 +55,8 @@ Python services share a centralized settings module at `services/common/config.p
 - Supported profiles: `local`, `staging`, `production` (`ENV_PROFILE`)
 - Profile templates: `infra/.env.local.example`, `infra/.env.staging.example`, `infra/.env.production.example`
 - Secret convention: use either `VAR` or `VAR_FILE` (file path), with `VAR_FILE` taking precedence
+
+For local Docker Compose, defaults in `infra/.env.local.example` target internal service names (`postgres`, `redis`, and service hostnames) so all services can connect through shared configuration.
 
 Do not commit real `.env` files or plaintext secrets.
 

--- a/infra/.env.local.example
+++ b/infra/.env.local.example
@@ -1,0 +1,58 @@
+# Local development profile
+ENV_PROFILE=local
+
+# Note: defaults below are tuned for Docker Compose service discovery.
+# If you run services directly on host, override hosts with localhost.
+
+# Service routing
+WALLET_SERVICE_URL=http://wallet:8001
+TOKENIZATION_SERVICE_URL=http://tokenization:8002
+MARKETPLACE_SERVICE_URL=http://marketplace:8003
+EDUCATION_SERVICE_URL=http://education:8004
+NOSTR_SERVICE_URL=http://nostr:8005
+
+# Database
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=tokenization
+POSTGRES_USER=local_user
+POSTGRES_PASSWORD=local_password
+# Optional secure alternative:
+# POSTGRES_PASSWORD_FILE=secrets/postgres_password.txt
+DATABASE_URL=postgresql://local_user:local_password@postgres:5432/tokenization
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Bitcoin Core
+BITCOIN_RPC_HOST=localhost
+BITCOIN_RPC_PORT=8332
+BITCOIN_RPC_USER=local_rpc
+BITCOIN_RPC_PASSWORD=local_rpc_password
+# BITCOIN_RPC_PASSWORD_FILE=secrets/bitcoin_rpc_password.txt
+BITCOIN_NETWORK=regtest
+
+# LND + tapd
+LND_GRPC_HOST=localhost
+LND_GRPC_PORT=10009
+LND_MACAROON_PATH=
+LND_TLS_CERT_PATH=
+TAPD_GRPC_HOST=localhost
+TAPD_GRPC_PORT=10029
+
+# Nostr
+NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+
+# Auth
+JWT_SECRET=local_jwt_secret
+# JWT_SECRET_FILE=secrets/jwt_secret.txt
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+TOTP_ISSUER=RWAPlatform
+
+# AI
+OPENAI_API_KEY=
+# OPENAI_API_KEY_FILE=secrets/openai_api_key.txt
+
+# Runtime
+LOG_LEVEL=DEBUG

--- a/infra/.env.production.example
+++ b/infra/.env.production.example
@@ -1,0 +1,50 @@
+# Production profile
+ENV_PROFILE=production
+
+# Service routing
+WALLET_SERVICE_URL=http://wallet:8001
+TOKENIZATION_SERVICE_URL=http://tokenization:8002
+MARKETPLACE_SERVICE_URL=http://marketplace:8003
+EDUCATION_SERVICE_URL=http://education:8004
+NOSTR_SERVICE_URL=http://nostr:8005
+
+# Database
+POSTGRES_HOST=prod-postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=tokenization
+POSTGRES_USER=tokenization
+POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+DATABASE_URL=postgresql://tokenization:REDACTED@prod-postgres:5432/tokenization
+
+# Redis
+REDIS_URL=redis://prod-redis:6379/0
+
+# Bitcoin Core
+BITCOIN_RPC_HOST=prod-bitcoind
+BITCOIN_RPC_PORT=8332
+BITCOIN_RPC_USER=rpc_user
+BITCOIN_RPC_PASSWORD_FILE=/run/secrets/bitcoin_rpc_password
+BITCOIN_NETWORK=mainnet
+
+# LND + tapd
+LND_GRPC_HOST=prod-lnd
+LND_GRPC_PORT=10009
+LND_MACAROON_PATH=/run/secrets/lnd_admin_macaroon
+LND_TLS_CERT_PATH=/run/secrets/lnd_tls_cert
+TAPD_GRPC_HOST=prod-tapd
+TAPD_GRPC_PORT=10029
+
+# Nostr
+NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+
+# Auth
+JWT_SECRET_FILE=/run/secrets/jwt_secret
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+TOTP_ISSUER=RWAPlatform
+
+# AI
+OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+
+# Runtime
+LOG_LEVEL=WARNING

--- a/infra/.env.staging.example
+++ b/infra/.env.staging.example
@@ -1,0 +1,50 @@
+# Staging profile
+ENV_PROFILE=staging
+
+# Service routing
+WALLET_SERVICE_URL=http://wallet:8001
+TOKENIZATION_SERVICE_URL=http://tokenization:8002
+MARKETPLACE_SERVICE_URL=http://marketplace:8003
+EDUCATION_SERVICE_URL=http://education:8004
+NOSTR_SERVICE_URL=http://nostr:8005
+
+# Database
+POSTGRES_HOST=staging-postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=tokenization_staging
+POSTGRES_USER=tokenization
+POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+DATABASE_URL=postgresql://tokenization:REDACTED@staging-postgres:5432/tokenization_staging
+
+# Redis
+REDIS_URL=redis://staging-redis:6379/0
+
+# Bitcoin Core
+BITCOIN_RPC_HOST=staging-bitcoind
+BITCOIN_RPC_PORT=8332
+BITCOIN_RPC_USER=rpc_user
+BITCOIN_RPC_PASSWORD_FILE=/run/secrets/bitcoin_rpc_password
+BITCOIN_NETWORK=testnet
+
+# LND + tapd
+LND_GRPC_HOST=staging-lnd
+LND_GRPC_PORT=10009
+LND_MACAROON_PATH=/run/secrets/lnd_admin_macaroon
+LND_TLS_CERT_PATH=/run/secrets/lnd_tls_cert
+TAPD_GRPC_HOST=staging-tapd
+TAPD_GRPC_PORT=10029
+
+# Nostr
+NOSTR_RELAYS=wss://relay.damus.io,wss://nos.lol
+
+# Auth
+JWT_SECRET_FILE=/run/secrets/jwt_secret
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+TOTP_ISSUER=RWAPlatform-Staging
+
+# AI
+OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+
+# Runtime
+LOG_LEVEL=INFO

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,11 +4,45 @@ Docker Compose files, Nginx/Traefik configuration, and environment templates.
 
 ## Contents
 
-- `docker/` — Dockerfiles and compose files for local development
+- `docker-compose.local.yml` — Local orchestration for shared platform infra and services
 - `.env.example` — Template for required environment variables
 - `.env.local.example` — Local development profile
 - `.env.staging.example` — Staging profile
 - `.env.production.example` — Production profile
+
+## Local orchestration (PostgreSQL + Redis + platform services)
+
+Run from repository root:
+
+```bash
+docker compose -f infra/docker-compose.local.yml up -d
+```
+
+This starts:
+
+- `postgres` on `localhost:5432`
+- `redis` on `localhost:6379`
+- `wallet`, `tokenization`, `marketplace`, `education`, `nostr`
+- `gateway` on `localhost:8000`
+
+Stop and clean up:
+
+```bash
+docker compose -f infra/docker-compose.local.yml down
+```
+
+To remove persisted local database/cache volumes:
+
+```bash
+docker compose -f infra/docker-compose.local.yml down -v
+```
+
+### Health checks
+
+- Gateway: `GET http://localhost:8000/health`
+- Wallet via gateway: `GET http://localhost:8000/v1/wallet/health`
+- PostgreSQL readiness: container healthcheck with `pg_isready`
+- Redis readiness: container healthcheck with `redis-cli ping`
 
 ## Shared Python Configuration
 

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1,0 +1,194 @@
+name: tokenization-local
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: tokenization-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: tokenization
+      POSTGRES_USER: local_user
+      POSTGRES_PASSWORD: local_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U local_user -d tokenization"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - platform
+
+  redis:
+    image: redis:7-alpine
+    container_name: tokenization-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - platform
+
+  wallet:
+    image: python:3.11-slim
+    container_name: tokenization-wallet
+    restart: unless-stopped
+    working_dir: /app/services/wallet
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn main:app --host 0.0.0.0 --port 8001"
+    env_file:
+      - ./.env.local.example
+    environment:
+      POSTGRES_HOST: postgres
+      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ../:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8001:8001"
+    networks:
+      - platform
+
+  tokenization:
+    image: python:3.11-slim
+    container_name: tokenization-tokenization
+    restart: unless-stopped
+    working_dir: /app/services/tokenization
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn main:app --host 0.0.0.0 --port 8002"
+    env_file:
+      - ./.env.local.example
+    environment:
+      POSTGRES_HOST: postgres
+      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ../:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8002:8002"
+    networks:
+      - platform
+
+  marketplace:
+    image: python:3.11-slim
+    container_name: tokenization-marketplace
+    restart: unless-stopped
+    working_dir: /app/services/marketplace
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn main:app --host 0.0.0.0 --port 8003"
+    env_file:
+      - ./.env.local.example
+    environment:
+      POSTGRES_HOST: postgres
+      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ../:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8003:8003"
+    networks:
+      - platform
+
+  education:
+    image: python:3.11-slim
+    container_name: tokenization-education
+    restart: unless-stopped
+    working_dir: /app/services/education
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn main:app --host 0.0.0.0 --port 8004"
+    env_file:
+      - ./.env.local.example
+    environment:
+      POSTGRES_HOST: postgres
+      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ../:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8004:8004"
+    networks:
+      - platform
+
+  nostr:
+    image: python:3.11-slim
+    container_name: tokenization-nostr
+    restart: unless-stopped
+    working_dir: /app/services/nostr
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn main:app --host 0.0.0.0 --port 8005"
+    env_file:
+      - ./.env.local.example
+    environment:
+      POSTGRES_HOST: postgres
+      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - ../:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8005:8005"
+    networks:
+      - platform
+
+  gateway:
+    build:
+      context: ../services/gateway
+      dockerfile: Dockerfile
+    container_name: tokenization-gateway
+    restart: unless-stopped
+    depends_on:
+      - wallet
+      - tokenization
+      - marketplace
+      - education
+      - nostr
+    ports:
+      - "8000:8000"
+    networks:
+      - platform
+
+volumes:
+  postgres_data:
+  redis_data:
+
+networks:
+  platform:
+    driver: bridge

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -5,16 +5,14 @@ services:
     image: postgres:15-alpine
     container_name: tokenization-postgres
     restart: unless-stopped
-    environment:
-      POSTGRES_DB: tokenization
-      POSTGRES_USER: local_user
-      POSTGRES_PASSWORD: local_password
+    env_file:
+      - ./.env.local.example
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U local_user -d tokenization"]
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -48,10 +46,6 @@ services:
       uvicorn main:app --host 0.0.0.0 --port 8001"
     env_file:
       - ./.env.local.example
-    environment:
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
-      REDIS_URL: redis://redis:6379/0
     volumes:
       - ../:/app
     depends_on:
@@ -74,10 +68,6 @@ services:
       uvicorn main:app --host 0.0.0.0 --port 8002"
     env_file:
       - ./.env.local.example
-    environment:
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
-      REDIS_URL: redis://redis:6379/0
     volumes:
       - ../:/app
     depends_on:
@@ -100,10 +90,6 @@ services:
       uvicorn main:app --host 0.0.0.0 --port 8003"
     env_file:
       - ./.env.local.example
-    environment:
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
-      REDIS_URL: redis://redis:6379/0
     volumes:
       - ../:/app
     depends_on:
@@ -126,10 +112,6 @@ services:
       uvicorn main:app --host 0.0.0.0 --port 8004"
     env_file:
       - ./.env.local.example
-    environment:
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
-      REDIS_URL: redis://redis:6379/0
     volumes:
       - ../:/app
     depends_on:
@@ -152,10 +134,6 @@ services:
       uvicorn main:app --host 0.0.0.0 --port 8005"
     env_file:
       - ./.env.local.example
-    environment:
-      POSTGRES_HOST: postgres
-      DATABASE_URL: postgresql://local_user:local_password@postgres:5432/tokenization
-      REDIS_URL: redis://redis:6379/0
     volumes:
       - ../:/app
     depends_on:

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,3 +1,4 @@
 from .config import Settings, get_settings
+from .readiness import get_readiness_payload
 
-__all__ = ["Settings", "get_settings"]
+__all__ = ["Settings", "get_settings", "get_readiness_payload"]

--- a/services/common/readiness.py
+++ b/services/common/readiness.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import socket
+from urllib.parse import urlparse
+
+from .config import Settings
+
+
+def _check_tcp_socket(host: str, port: int, timeout_seconds: float = 1.5) -> tuple[bool, str | None]:
+    try:
+        with socket.create_connection((host, port), timeout=timeout_seconds):
+            return True, None
+    except OSError as exc:
+        return False, str(exc)
+
+
+def _redis_endpoint(redis_url: str) -> tuple[str, int]:
+    parsed = urlparse(redis_url)
+    if parsed.hostname:
+        return parsed.hostname, parsed.port or 6379
+
+    # Fallback for non-standard URL-like values.
+    candidate = redis_url.replace("redis://", "", 1).split("/", 1)[0]
+    if ":" in candidate:
+        host, raw_port = candidate.rsplit(":", 1)
+        return host, int(raw_port)
+    return candidate, 6379
+
+
+def _check_redis_ping(redis_url: str) -> tuple[bool, str | None, str]:
+    host, port = _redis_endpoint(redis_url)
+    try:
+        with socket.create_connection((host, port), timeout=1.5) as conn:
+            conn.settimeout(1.5)
+            conn.sendall(b"*1\r\n$4\r\nPING\r\n")
+            response = conn.recv(16)
+            if response.startswith(b"+PONG"):
+                return True, None, f"{host}:{port}"
+            return False, f"Unexpected redis response: {response!r}", f"{host}:{port}"
+    except OSError as exc:
+        return False, str(exc), f"{host}:{port}"
+
+
+def get_readiness_payload(settings: Settings) -> dict:
+    postgres_ok, postgres_error = _check_tcp_socket(settings.postgres_host, settings.postgres_port)
+    redis_ok, redis_error, redis_target = _check_redis_ping(settings.redis_url)
+
+    dependencies = {
+        "postgres": {
+            "ok": postgres_ok,
+            "target": f"{settings.postgres_host}:{settings.postgres_port}",
+            "error": postgres_error,
+        },
+        "redis": {
+            "ok": redis_ok,
+            "target": redis_target,
+            "error": redis_error,
+        },
+    }
+
+    all_ready = postgres_ok and redis_ok
+    return {
+        "status": "ready" if all_ready else "not_ready",
+        "service": settings.service_name,
+        "env_profile": settings.env_profile,
+        "dependencies": dependencies,
+    }

--- a/services/education/main.py
+++ b/services/education/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 import sys
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from common import get_settings
+from common import get_readiness_payload, get_settings
 
 settings = get_settings(service_name="education", default_port=8004)
 
@@ -19,6 +20,13 @@ async def health():
         "service": settings.service_name,
         "env_profile": settings.env_profile,
     }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/marketplace/main.py
+++ b/services/marketplace/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 import sys
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from common import get_settings
+from common import get_readiness_payload, get_settings
 
 settings = get_settings(service_name="marketplace", default_port=8003)
 
@@ -19,6 +20,13 @@ async def health():
         "service": settings.service_name,
         "env_profile": settings.env_profile,
     }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/nostr/main.py
+++ b/services/nostr/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 import sys
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from common import get_settings
+from common import get_readiness_payload, get_settings
 
 settings = get_settings(service_name="nostr", default_port=8005)
 
@@ -19,6 +20,13 @@ async def health():
         "service": settings.service_name,
         "env_profile": settings.env_profile,
     }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/tokenization/main.py
+++ b/services/tokenization/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 import sys
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from common import get_settings
+from common import get_readiness_payload, get_settings
 
 settings = get_settings(service_name="tokenization", default_port=8002)
 
@@ -19,6 +20,13 @@ async def health():
         "service": settings.service_name,
         "env_profile": settings.env_profile,
     }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/wallet/main.py
+++ b/services/wallet/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 import sys
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from common import get_settings
+from common import get_readiness_payload, get_settings
 
 settings = get_settings(service_name="wallet", default_port=8001)
 
@@ -19,6 +20,13 @@ async def health():
         "service": settings.service_name,
         "env_profile": settings.env_profile,
     }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)


### PR DESCRIPTION
### feat(infra): add local core infrastructure and shared env templates for local orchestration

**Description**

This PR introduces the core local infrastructure for end-to-end development, adding Docker Compose orchestration for PostgreSQL, Redis, and platform services.
It also standardizes environment variable templates per profile and updates the local startup documentation.

**Problem Solved**

Previously, there was no complete local orchestration to bring up core dependencies (PostgreSQL and Redis) together with platform services, making it difficult for developers to validate end-to-end flows consistently.

**Main Changes**

- Added local infrastructure and service stack in [docker-compose.local.yml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Included/tracked environment templates per profile:
[.env.local.example](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [.env.staging.example](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [.env.production.example](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Updated [.gitignore](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to allow versioning of .env.*.example files.
- Documented local startup and health checks in [README.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [README.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

### Technical Details

**Local orchestration:**

- PostgreSQL 15 with persistent volume and healthcheck.
- Redis 7 with AOF and healthcheck.
- Services: wallet, tokenization, marketplace, education, nostr.
- API Gateway exposed on localhost:8000.
- Startup dependencies configured to wait for healthy postgres/redis.
- Shared configuration:

1. Services consume common variables from the env file in compose.
2. The local profile uses Docker network hostnames (postgres, redis, service names), enabling internal connectivity with no extra manual config.

**Documentation:**

- Commands for starting/stopping the local stack.
- Basic health checks via gateway.
- Explicit note about using per-profile templates.
- Acceptance Criteria Covered

- PostgreSQL and Redis can be started from local orchestration: covered in [docker-compose.local.yml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Services connect to infrastructure using shared configuration: covered with templates in [.env.local.example](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and compose usage.
- Local documentation reflects new dependencies: covered in [README.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [README.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

**Commits included in this branch**

- feat(infra): add local compose stack with postgres and redis
- chore(config): track environment profile example files
- docs(readme): add documentation for starting services

**How to quickly validate**

- docker compose -f [docker-compose.local.yml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) up -d
- Check health:
[http://localhost:8000/health](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[http://localhost:8000/v1/wallet/health](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- docker compose -f [docker-compose.local.yml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) down
