### PR TITLE
feat(auth): implement Nostr authentication and identity bridge

### DIFF
--- a/services/auth/db.py
+++ b/services/auth/db.py
@@ -23,6 +23,7 @@ from common.db.metadata import (
     refresh_token_sessions as refresh_token_sessions_table,
     users as users_table,
     wallets as wallets_table,
+    nostr_identities as nostr_identities_table,
 )
 
 
@@ -162,3 +163,57 @@ async def revoke_refresh_session(
 
     await conn.commit()
     return True
+
+
+async def get_nostr_identity_by_pubkey(
+    conn: AsyncConnection, pubkey: str
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(nostr_identities_table).where(
+            nostr_identities_table.c.pubkey == pubkey
+        )
+    )
+    return result.fetchone()
+
+
+async def create_nostr_user(
+    conn: AsyncConnection,
+    *,
+    display_name: str,
+) -> sa.engine.Row:
+    """Insert a new user initialized via Nostr (no email/password)."""
+    new_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    await conn.execute(
+        sa.insert(users_table).values(
+            id=new_id,
+            display_name=display_name,
+            role="user",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await conn.commit()
+    row = await get_user_by_id(conn, str(new_id))
+    assert row is not None  # just inserted
+    return row
+
+
+async def create_nostr_identity(
+    conn: AsyncConnection,
+    *,
+    user_id: str,
+    pubkey: str,
+    relay_urls: list[str] | None = None,
+) -> None:
+    now = datetime.now(tz=timezone.utc)
+    await conn.execute(
+        sa.insert(nostr_identities_table).values(
+            id=uuid.uuid4(),
+            user_id=_as_uuid(user_id),
+            pubkey=pubkey,
+            relay_urls=relay_urls,
+            created_at=now,
+        )
+    )
+    await conn.commit()

--- a/services/auth/main.py
+++ b/services/auth/main.py
@@ -37,6 +37,7 @@ from .schemas import (
     LoginRequest,
     LogoutRequest,
     MessageResponse,
+    NostrLoginRequest,
     RefreshRequest,
     RegisterRequest,
     RoleCheckResponse,
@@ -44,9 +45,13 @@ from .schemas import (
     UserOut,
 )
 from .jwt_utils import decode_token, issue_token_pair
+from .nostr_utils import validate_nostr_event, NostrValidationError
 from .db import (
+    create_nostr_identity,
+    create_nostr_user,
     create_refresh_session,
     create_user,
+    get_nostr_identity_by_pubkey,
     get_user_by_email,
     get_user_by_id,
     revoke_refresh_session,
@@ -364,6 +369,54 @@ async def login(body: LoginRequest):
     async with _engine.connect() as conn:  # type: AsyncConnection
         return await _issue_auth_response(
             row,
+            conn=conn,
+            status_code=status.HTTP_200_OK,
+        )
+
+
+@app.post(
+    "/auth/nostr",
+    status_code=status.HTTP_200_OK,
+    response_model=AuthResponse,
+    summary="Log in or register with a Nostr identity",
+)
+async def nostr_login(body: NostrLoginRequest):
+    """Authenticate via Nostr signature challenge."""
+    try:
+        validate_nostr_event(body.pubkey, body.signed_event)
+    except NostrValidationError as e:
+        return _error(
+            "invalid_credentials",
+            str(e),
+            status.HTTP_401_UNAUTHORIZED,
+        )
+
+    async with _engine.connect() as conn:  # type: AsyncConnection
+        identity_row = await get_nostr_identity_by_pubkey(conn, body.pubkey)
+        
+        if identity_row is not None:
+            user_row = await get_user_by_id(conn, str(identity_row.user_id))
+            if user_row is None:
+                return _error(
+                    "invalid_credentials",
+                    "Linked user account not found.",
+                    status.HTTP_401_UNAUTHORIZED,
+                )
+        else:
+            display_name = f"nostr:{body.pubkey[:8]}"
+            user_row = await create_nostr_user(
+                conn,
+                display_name=display_name,
+            )
+            await create_nostr_identity(
+                conn,
+                user_id=str(user_row.id),
+                pubkey=body.pubkey,
+                relay_urls=None,
+            )
+
+        return await _issue_auth_response(
+            user_row,
             conn=conn,
             status_code=status.HTTP_200_OK,
         )

--- a/services/auth/nostr_utils.py
+++ b/services/auth/nostr_utils.py
@@ -1,0 +1,89 @@
+"""Nostr utility functions for authenticating NIP-98 style requests.
+
+Implements NIP-01 event ID serialization and Schnorr signature verification.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+
+try:
+    import secp256k1
+except ImportError:
+    secp256k1 = None
+
+from services.auth.schemas import NostrSignedEvent
+
+
+class NostrValidationError(Exception):
+    """Raised when a Nostr event fails validation."""
+    pass
+
+
+def validate_nostr_event(pubkey: str, event: NostrSignedEvent) -> None:
+    """Validate a NIP-98 style Nostr auth event.
+
+    Raises:
+        NostrValidationError: If the event is invalid.
+    """
+    if event.kind != 22242:
+        raise NostrValidationError("Event kind must be 22242 for authentication.")
+
+    if not event.content.startswith("Sign-in challenge:"):
+        raise NostrValidationError("Invalid challenge format in event content.")
+
+    now = int(time.time())
+    if abs(now - event.created_at) > 300:
+        raise NostrValidationError("Event timestamp is too old or in the future.")
+
+    # 1. Verify Event ID
+    serialized = json.dumps(
+        [
+            0,
+            pubkey,
+            event.created_at,
+            event.kind,
+            event.tags,
+            event.content,
+        ],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    event_id_bytes = hashlib.sha256(serialized.encode("utf-8")).digest()
+    expected_id = event_id_bytes.hex()
+    
+    if expected_id != event.id:
+        raise NostrValidationError("Event ID does not match serialized content.")
+
+    # 2. Verify Schnorr Signature
+    if secp256k1 is None:
+        raise RuntimeError("secp256k1 library is not installed.")
+
+    try:
+        pubkey_bytes = bytes.fromhex(pubkey)
+        if len(pubkey_bytes) != 32:
+            raise NostrValidationError("Pubkey must be exactly 32 bytes.")
+            
+        sig_bytes = bytes.fromhex(event.sig)
+        if len(sig_bytes) != 64:
+            raise NostrValidationError("Signature must be exactly 64 bytes.")
+
+        # python-secp256k1 (bindings) exposes PublicKey but parsing a 32-byte
+        # NIP-01 pubkey normally requires instantiating an XOnly pubkey.
+        # However, due to API differences, we can just prepend 0x02 to parse it,
+        # then extract the schnorr verification out of it.
+        # Alternatively, secp256k1.PublicKey supports `schnorr_verify`.
+        # Note: In standard python-secp256k1 `secp256k1.PublicKey(b'\\x02' + pub_bytes, raw=True)`
+        # `pk.schnorr_verify(msg_bytes, sig_bytes, b'', raw=True)` works.
+        b_pubkey = b"\x02" + pubkey_bytes
+        pk = secp256k1.PublicKey(b_pubkey, raw=True)
+        
+        # Verify the signature
+        if not pk.schnorr_verify(event_id_bytes, sig_bytes, b"", raw=True):
+            raise NostrValidationError("Invalid Schnorr signature.")
+            
+    except Exception as e:
+        if isinstance(e, NostrValidationError):
+            raise e
+        raise NostrValidationError(f"Invalid signature bytes: {e}")

--- a/services/auth/schemas.py
+++ b/services/auth/schemas.py
@@ -43,16 +43,31 @@ class LogoutRequest(BaseModel):
     refresh_token: str = Field(min_length=1)
 
 
+class NostrSignedEvent(BaseModel):
+    id: str = Field(min_length=64, max_length=64)
+    kind: int
+    created_at: int
+    content: str
+    tags: list[list[str]] = []
+    sig: str = Field(min_length=128, max_length=128)
+
+
+class NostrLoginRequest(BaseModel):
+    pubkey: str = Field(min_length=64, max_length=64)
+    signed_event: NostrSignedEvent
+
+
 # ---------------------------------------------------------------------------
 # Response schemas
 # ---------------------------------------------------------------------------
 
 class UserOut(BaseModel):
     id: str
-    email: str
+    email: str | None = None
     display_name: str
     role: str
     created_at: datetime
+
 
 
 class TokensOut(BaseModel):

--- a/specs/database-schema.md
+++ b/specs/database-schema.md
@@ -115,7 +115,6 @@ production
 developer (local)
 staging (pre produccion)
 
-
 ### 3.4 `transactions`
 
 Immutable ledger of all financial movements.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -615,3 +615,95 @@ class TestProtectedEndpoints:
         assert body["id"] == str(fake_user.id)
         assert body["email"] == fake_user.email
         assert body["role"] == "seller"
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/nostr
+# ---------------------------------------------------------------------------
+
+class TestNostrAuth:
+    def test_nostr_login_first_time_creates_user(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user(email=None, password="")
+        
+        with (
+            patch("services.auth.main.validate_nostr_event", MagicMock(return_value=None)),
+            patch("services.auth.main.get_nostr_identity_by_pubkey", AsyncMock(return_value=None)),
+            patch("services.auth.main.create_nostr_user", AsyncMock(return_value=fake_user)),
+            patch("services.auth.main.create_nostr_identity", AsyncMock(return_value=None)),
+            patch("services.auth.main.create_refresh_session", AsyncMock(return_value=None)),
+        ):
+            resp = app_client.post(
+                "/auth/nostr",
+                json={
+                    "pubkey": "a" * 64,
+                    "signed_event": {
+                        "id": "b" * 64,
+                        "kind": 22242,
+                        "created_at": 1234567890,
+                        "content": "Sign-in challenge: 123",
+                        "sig": "c" * 128
+                    }
+                }
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "user" in body
+        assert "tokens" in body
+        assert body["user"]["email"] is None
+        _assert_token_structure(body["tokens"])
+
+    def test_nostr_login_existing_identity_returns_tokens(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user(email="test@nostr.com", password="")
+        fake_identity = MagicMock(user_id=fake_user.id)
+        
+        with (
+            patch("services.auth.main.validate_nostr_event", MagicMock(return_value=None)),
+            patch("services.auth.main.get_nostr_identity_by_pubkey", AsyncMock(return_value=fake_identity)),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+            patch("services.auth.main.create_refresh_session", AsyncMock(return_value=None)),
+        ):
+            resp = app_client.post(
+                "/auth/nostr",
+                json={
+                    "pubkey": "a" * 64,
+                    "signed_event": {
+                        "id": "b" * 64,
+                        "kind": 22242,
+                        "created_at": 1234567890,
+                        "content": "Sign-in challenge: 123",
+                        "sig": "c" * 128
+                    }
+                }
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["user"]["email"] == "test@nostr.com"
+
+    def test_nostr_login_invalid_signature_returns_401(self, client):
+        app_client, fake_conn, settings = client
+        from services.auth.nostr_utils import NostrValidationError
+        
+        with (
+            patch("services.auth.main.validate_nostr_event", MagicMock(side_effect=NostrValidationError("Bad sig"))),
+        ):
+            resp = app_client.post(
+                "/auth/nostr",
+                json={
+                    "pubkey": "a" * 64,
+                    "signed_event": {
+                        "id": "b" * 64,
+                        "kind": 22242,
+                        "created_at": 1234567890,
+                        "content": "Sign-in challenge: 123",
+                        "sig": "c" * 128
+                    }
+                }
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["error"]["code"] == "invalid_credentials"
+        assert "Bad sig" in resp.json()["error"]["message"]


### PR DESCRIPTION
Implementing Nostr-based authentication (NIP-98/NIP-01) for the auth service. Includes signature verification, identity linking, and automated user provisioning.