### PR TITLE
feat: implement TOTP 2FA enrollment and verification

### DIFF
--- a/services/auth/db.py
+++ b/services/auth/db.py
@@ -49,6 +49,33 @@ async def get_user_by_id(
     return result.fetchone()
 
 
+async def enable_2fa(
+    conn: AsyncConnection,
+    user_id: str,
+    totp_secret: str,
+    backup_codes: list[str],
+) -> None:
+    """Set the TOTP secret and backup codes for a user."""
+    await conn.execute(
+        sa.update(users_table)
+        .where(users_table.c.id == _as_uuid(user_id))
+        .values(totp_secret=totp_secret, backup_codes=backup_codes)
+    )
+    await conn.commit()
+
+
+async def get_user_2fa_secret(
+    conn: AsyncConnection, user_id: str
+) -> str | None:
+    """Return the user's totp_secret if set."""
+    result = await conn.execute(
+        sa.select(users_table.c.totp_secret).where(
+            users_table.c.id == _as_uuid(user_id)
+        )
+    )
+    return result.scalar()
+
+
 async def create_user(
     conn: AsyncConnection,
     *,

--- a/services/auth/main.py
+++ b/services/auth/main.py
@@ -19,7 +19,18 @@ from pathlib import Path
 import sys
 import uuid
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Security, status
+from typing import Annotated, Optional
+
+import pyotp
+from fastapi import (
+    Depends,
+    FastAPI,
+    Header,
+    HTTPException,
+    Request,
+    Security,
+    status,
+)
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -42,6 +53,8 @@ from .schemas import (
     RegisterRequest,
     RoleCheckResponse,
     TokensOut,
+    TwoFactorEnableResponse,
+    TwoFactorVerifyRequest,
     UserOut,
 )
 from .jwt_utils import decode_token, issue_token_pair
@@ -51,7 +64,9 @@ from .db import (
     create_nostr_user,
     create_refresh_session,
     create_user,
+    enable_2fa,
     get_nostr_identity_by_pubkey,
+    get_user_2fa_secret,
     get_user_by_email,
     get_user_by_id,
     revoke_refresh_session,
@@ -141,6 +156,32 @@ def _normalize_uuid_claim(value: object) -> str | None:
         return str(uuid.UUID(str(value)))
     except (TypeError, ValueError, AttributeError):
         return None
+
+
+async def _require_2fa(
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+    x_2fa_code: Annotated[str | None, Header()] = None,
+) -> None:
+    """Dependency that enforces X-2FA-Code if 2FA is enabled for the user."""
+    async with _engine.connect() as conn:
+        secret = await get_user_2fa_secret(conn, principal.id)
+
+    # Only enforce if 2FA is actually enabled
+    if secret:
+        if not x_2fa_code:
+            raise ContractError(
+                code="2fa_required",
+                message="Two-factor authentication code is required for this operation.",
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        totp = pyotp.TOTP(secret)
+        if not totp.verify(x_2fa_code, valid_window=1):
+            raise ContractError(
+                code="invalid_2fa_code",
+                message="The provided two-factor authentication code is invalid or expired.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
 
 
 def _user_out(row) -> UserOut:
@@ -331,6 +372,80 @@ async def register(body: RegisterRequest):
             conn=conn,
             status_code=status.HTTP_201_CREATED,
         )
+
+
+@app.post(
+    "/auth/2fa/enable",
+    response_model=TwoFactorEnableResponse,
+    summary="Enable two-factor authentication",
+)
+async def enable_2fa_endpoint(
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    """Generate a TOTP secret and backup codes for the user."""
+    async with _engine.connect() as conn:
+        existing_secret = await get_user_2fa_secret(conn, principal.id)
+        if existing_secret:
+            raise ContractError(
+                code="2fa_already_enabled",
+                message="Two-factor authentication is already enabled for this account.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        # Generate TOTP secret
+        totp_secret = pyotp.random_base32()
+
+        # Generate 8 backup codes (8-char hex strings)
+        backup_codes = [uuid.uuid4().hex[:8] for _ in range(8)]
+
+        await enable_2fa(
+            conn,
+            user_id=principal.id,
+            totp_secret=totp_secret,
+            backup_codes=backup_codes,
+        )
+
+    # Build provisioning URI
+    totp = pyotp.TOTP(totp_secret)
+    totp_uri = totp.provisioning_uri(
+        name=principal.email or principal.display_name,
+        issuer_name=settings.totp_issuer,
+    )
+
+    return TwoFactorEnableResponse(
+        totp_uri=totp_uri,
+        backup_codes=backup_codes,
+    )
+
+
+@app.post(
+    "/auth/2fa/verify",
+    summary="Verify a two-factor authentication code",
+)
+async def verify_2fa_endpoint(
+    body: TwoFactorVerifyRequest,
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    """Verify a TOTP code to confirm 2FA works."""
+    async with _engine.connect() as conn:
+        secret = await get_user_2fa_secret(conn, principal.id)
+
+    if not secret:
+        raise ContractError(
+            code="2fa_not_enabled",
+            message="Two-factor authentication is not enabled for this account.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    totp = pyotp.TOTP(secret)
+    if not totp.verify(body.totp_code, valid_window=1):
+        raise ContractError(
+            code="invalid_2fa_code",
+            message="The provided two-factor authentication code is invalid or expired.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    return {"message": "2FA verification successful."}
 
 
 @app.post(

--- a/services/auth/main.py
+++ b/services/auth/main.py
@@ -158,32 +158,6 @@ def _normalize_uuid_claim(value: object) -> str | None:
         return None
 
 
-async def _require_2fa(
-    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
-    x_2fa_code: Annotated[str | None, Header()] = None,
-) -> None:
-    """Dependency that enforces X-2FA-Code if 2FA is enabled for the user."""
-    async with _engine.connect() as conn:
-        secret = await get_user_2fa_secret(conn, principal.id)
-
-    # Only enforce if 2FA is actually enabled
-    if secret:
-        if not x_2fa_code:
-            raise ContractError(
-                code="2fa_required",
-                message="Two-factor authentication code is required for this operation.",
-                status_code=status.HTTP_403_FORBIDDEN,
-            )
-
-        totp = pyotp.TOTP(secret)
-        if not totp.verify(x_2fa_code, valid_window=1):
-            raise ContractError(
-                code="invalid_2fa_code",
-                message="The provided two-factor authentication code is invalid or expired.",
-                status_code=status.HTTP_401_UNAUTHORIZED,
-            )
-
-
 def _user_out(row) -> UserOut:
     return UserOut(
         id=str(row.id),
@@ -276,6 +250,32 @@ async def _get_current_principal(
         role=row.role,
         created_at=row.created_at,
     )
+
+
+async def _require_2fa(
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+    x_2fa_code: Annotated[str | None, Header(None)] = None,
+) -> None:
+    """Dependency that enforces X-2FA-Code if 2FA is enabled for the user."""
+    async with _engine.connect() as conn:
+        secret = await get_user_2fa_secret(conn, principal.id)
+
+    # Only enforce if 2FA is actually enabled
+    if secret:
+        if not x_2fa_code:
+            raise ContractError(
+                code="2fa_required",
+                message="Two-factor authentication code is required for this operation.",
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        totp = pyotp.TOTP(secret)
+        if not totp.verify(x_2fa_code, valid_window=1):
+            raise ContractError(
+                code="invalid_2fa_code",
+                message="The provided two-factor authentication code is invalid or expired.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
 
 
 def _require_roles(*allowed_roles: str):

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy>=2.0.36
 asyncpg>=0.30.0
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
+pyotp>=2.9.0

--- a/services/auth/schemas.py
+++ b/services/auth/schemas.py
@@ -91,6 +91,15 @@ class RoleCheckResponse(BaseModel):
     required_roles: list[str]
 
 
+class TwoFactorEnableResponse(BaseModel):
+    totp_uri: str
+    backup_codes: list[str]
+
+
+class TwoFactorVerifyRequest(BaseModel):
+    totp_code: str = Field(min_length=6, max_length=6)
+
+
 # ---------------------------------------------------------------------------
 # Error schema (contract: { "error": { "code": "...", "message": "..." } })
 # ---------------------------------------------------------------------------

--- a/services/common/db/metadata.py
+++ b/services/common/db/metadata.py
@@ -23,6 +23,7 @@ users = sa.Table(
     sa.Column("display_name", sa.String(length=100), nullable=False),
     sa.Column("role", sa.String(length=20), nullable=False, server_default="user"),
     sa.Column("totp_secret", sa.String(length=255), nullable=True),
+    sa.Column("backup_codes", postgresql.JSONB, nullable=True),
     sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
     sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
     sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -707,3 +707,111 @@ class TestNostrAuth:
         assert resp.status_code == 401
         assert resp.json()["error"]["code"] == "invalid_credentials"
         assert "Bad sig" in resp.json()["error"]["message"]
+
+
+class TestTwoFactor:
+    """Tests for 2FA enrollment and verification flows."""
+
+    def test_enable_2fa_returns_totp_uri_and_backup_codes(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user("alice@example.com", "password")
+
+        with (
+            patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=None)),
+            patch("services.auth.main.enable_2fa", AsyncMock(return_value=None)),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+        ):
+            # We need an access token for the authenticated endpoints
+            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+
+            resp = app_client.post("/auth/2fa/enable", headers=headers)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "totp_uri" in body
+        assert "backup_codes" in body
+        assert body["totp_uri"].startswith("otpauth://totp/")
+        assert "secret=" in body["totp_uri"]
+        assert len(body["backup_codes"]) == 8
+
+    def test_enable_2fa_already_enabled_returns_409(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user("alice@example.com", "password")
+
+        with (
+            patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value="SECRET")),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+        ):
+            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+
+            resp = app_client.post("/auth/2fa/enable", headers=headers)
+
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "2fa_already_enabled"
+
+    def test_verify_2fa_valid_code_returns_success(self, client):
+        import pyotp
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user("alice@example.com", "password")
+        secret = "JBSWY3DPEHPK3PXP" # Base32
+        totp = pyotp.TOTP(secret)
+        valid_code = totp.now()
+
+        with (
+            patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=secret)),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+        ):
+            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+
+            resp = app_client.post(
+                "/auth/2fa/verify",
+                json={"totp_code": valid_code},
+                headers=headers
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "2FA verification successful."
+
+    def test_verify_2fa_invalid_code_returns_401(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user("alice@example.com", "password")
+        secret = "JBSWY3DPEHPK3PXP" # Base32
+
+        with (
+            patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=secret)),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+        ):
+            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+
+            resp = app_client.post(
+                "/auth/2fa/verify",
+                json={"totp_code": "000000"},
+                headers=headers
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["error"]["code"] == "invalid_2fa_code"
+
+    def test_verify_2fa_not_enabled_returns_400(self, client):
+        app_client, fake_conn, settings = client
+        fake_user = _make_fake_user("alice@example.com", "password")
+
+        with (
+            patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=None)),
+            patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+        ):
+            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+
+            resp = app_client.post(
+                "/auth/2fa/verify",
+                json={"totp_code": "123456"},
+                headers=headers
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "2fa_not_enabled"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -722,8 +722,8 @@ class TestTwoFactor:
             patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
         ):
             # We need an access token for the authenticated endpoints
-            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
-            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+            token_pair = issue_token_pair(user_id=str(fake_user.id), role=fake_user.role, wallet_id=None, secret=settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair.access_token}"}
 
             resp = app_client.post("/auth/2fa/enable", headers=headers)
 
@@ -743,8 +743,8 @@ class TestTwoFactor:
             patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value="SECRET")),
             patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
         ):
-            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
-            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+            token_pair = issue_token_pair(user_id=str(fake_user.id), role=fake_user.role, wallet_id=None, secret=settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair.access_token}"}
 
             resp = app_client.post("/auth/2fa/enable", headers=headers)
 
@@ -763,8 +763,8 @@ class TestTwoFactor:
             patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=secret)),
             patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
         ):
-            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
-            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+            token_pair = issue_token_pair(user_id=str(fake_user.id), role=fake_user.role, wallet_id=None, secret=settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair.access_token}"}
 
             resp = app_client.post(
                 "/auth/2fa/verify",
@@ -784,8 +784,8 @@ class TestTwoFactor:
             patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=secret)),
             patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
         ):
-            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
-            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+            token_pair = issue_token_pair(user_id=str(fake_user.id), role=fake_user.role, wallet_id=None, secret=settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair.access_token}"}
 
             resp = app_client.post(
                 "/auth/2fa/verify",
@@ -804,8 +804,8 @@ class TestTwoFactor:
             patch("services.auth.main.get_user_2fa_secret", AsyncMock(return_value=None)),
             patch("services.auth.main.get_user_by_id", AsyncMock(return_value=fake_user)),
         ):
-            token_pair = issue_token_pair(str(fake_user.id), fake_user.role, None, settings.jwt_secret)
-            headers = {"Authorization": f"Bearer {token_pair['access_token']}"}
+            token_pair = issue_token_pair(user_id=str(fake_user.id), role=fake_user.role, wallet_id=None, secret=settings.jwt_secret)
+            headers = {"Authorization": f"Bearer {token_pair.access_token}"}
 
             resp = app_client.post(
                 "/auth/2fa/verify",


### PR DESCRIPTION
This PR implements Issue 012: 2FA Enrollment and Verification for the Auth Service.

Closes #15

### Changes:
- Added pyotp dependency for TOTP logic.
- Updated users table schema with ackup_codes (JSONB).
- Implemented POST /auth/2fa/enable and POST /auth/2fa/verify.
- Added _require_2fa FastAPI dependency to secure sensitive operations via the X-2FA-Code header.
- Added comprehensive unit tests in 	ests/test_auth.py (5/5 PASS).

Verified with local pytest suite.