### PR TITLE
Feat/dispute resolutions

### DIFF
--- a/alembic/versions/20260414_1400_0007_add_disputes.py
+++ b/alembic/versions/20260414_1400_0007_add_disputes.py
@@ -1,0 +1,78 @@
+"""add disputes table
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-04-14 14:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "disputes",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("trade_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("opened_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=10),
+            nullable=False,
+            server_default="open",
+        ),
+        sa.Column("resolution", sa.String(length=10), nullable=True),
+        sa.Column("resolved_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["trade_id"],
+            ["trades.id"],
+            name="fk_disputes_trade_id_trades",
+        ),
+        sa.ForeignKeyConstraint(
+            ["opened_by"],
+            ["users.id"],
+            name="fk_disputes_opened_by_users",
+        ),
+        sa.ForeignKeyConstraint(
+            ["resolved_by"],
+            ["users.id"],
+            name="fk_disputes_resolved_by_users",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_disputes"),
+        sa.UniqueConstraint("trade_id", name="uq_disputes_trade_id"),
+        sa.CheckConstraint("status IN ('open', 'resolved')", name="ck_disputes_status_allowed"),
+        sa.CheckConstraint(
+            "resolution IS NULL OR resolution IN ('refund', 'release')",
+            name="ck_disputes_resolution_allowed",
+        ),
+    )
+    op.create_index("ix_disputes_status", "disputes", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_disputes_status", table_name="disputes")
+    op.drop_table("disputes")

--- a/services/common/db/metadata.py
+++ b/services/common/db/metadata.py
@@ -321,3 +321,28 @@ enrollments = sa.Table(
     sa.UniqueConstraint("user_id", "course_id", name="uq_enrollments_user_course"),
     sa.CheckConstraint("progress >= 0 AND progress <= 100", name="progress_range"),
 )
+
+disputes = sa.Table(
+    "disputes",
+    metadata,
+    sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+    sa.Column("trade_id", postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column("opened_by", postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column("reason", sa.Text(), nullable=False),
+    sa.Column("status", sa.String(length=10), nullable=False, server_default="open"),
+    sa.Column("resolution", sa.String(length=10), nullable=True),
+    sa.Column("resolved_by", postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    sa.ForeignKeyConstraint(["trade_id"], ["trades.id"], name="fk_disputes_trade_id_trades"),
+    sa.ForeignKeyConstraint(["opened_by"], ["users.id"], name="fk_disputes_opened_by_users"),
+    sa.ForeignKeyConstraint(["resolved_by"], ["users.id"], name="fk_disputes_resolved_by_users"),
+    sa.UniqueConstraint("trade_id", name="uq_disputes_trade_id"),
+    sa.Index("ix_disputes_status", "status"),
+    sa.CheckConstraint("status IN ('open', 'resolved')", name="status_allowed"),
+    sa.CheckConstraint(
+        "resolution IS NULL OR resolution IN ('refund', 'release')",
+        name="resolution_allowed",
+    ),
+)

--- a/services/marketplace/db.py
+++ b/services/marketplace/db.py
@@ -21,6 +21,7 @@ from common.db.metadata import tokens as tokens_table
 from common.db.metadata import trades as trades_table
 from common.db.metadata import users as users_table
 from common.db.metadata import wallets as wallets_table
+from common.db.metadata import disputes as disputes_table
 from marketplace.escrow import compress_xonly_pubkey, derive_compressed_pubkey, generate_2of3_multisig_address
 
 
@@ -798,3 +799,205 @@ def _generate_release_txid(escrow_id: uuid.UUID, trade_id: uuid.UUID) -> str:
 
     payload = f"release:{escrow_id}:{trade_id}:{_time.time_ns()}".encode()
     return hashlib.sha256(payload).hexdigest()
+
+
+async def get_dispute_by_trade_id(
+    conn: AsyncConnection,
+    trade_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(disputes_table).where(disputes_table.c.trade_id == _as_uuid(trade_id))
+    )
+    return result.fetchone()
+
+
+async def open_dispute(
+    conn: AsyncConnection,
+    *,
+    trade_id: str | uuid.UUID,
+    opened_by: str | uuid.UUID,
+    reason: str,
+) -> sa.engine.Row:
+    """Create a dispute for an escrowed trade.
+
+    Sets the trade and its escrow to ``disputed`` status atomically, then
+    inserts the dispute record.  Returns the new dispute row.
+    """
+    now = _utc_now()
+    trade_id_uuid = _as_uuid(trade_id)
+
+    try:
+        trade_result = await conn.execute(
+            sa.update(trades_table)
+            .where(trades_table.c.id == trade_id_uuid)
+            .where(trades_table.c.status == "escrowed")
+            .values(status="disputed")
+            .returning(trades_table)
+        )
+        if trade_result.fetchone() is None:
+            raise LookupError("trade_not_found_or_state_conflict")
+
+        escrow_result = await conn.execute(
+            sa.update(escrows_table)
+            .where(escrows_table.c.trade_id == trade_id_uuid)
+            .where(escrows_table.c.status == "funded")
+            .values(status="disputed", updated_at=now)
+            .returning(escrows_table)
+        )
+        if escrow_result.fetchone() is None:
+            raise LookupError("escrow_not_found_or_state_conflict")
+
+        dispute_result = await conn.execute(
+            sa.insert(disputes_table)
+            .values(
+                id=uuid.uuid4(),
+                trade_id=trade_id_uuid,
+                opened_by=_as_uuid(opened_by),
+                reason=reason,
+                status="open",
+                resolution=None,
+                resolved_by=None,
+                resolved_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+            .returning(disputes_table)
+        )
+        dispute_row = dispute_result.fetchone()
+        assert dispute_row is not None
+
+        await conn.commit()
+    except Exception:
+        await conn.rollback()
+        raise
+
+    return dispute_row
+
+
+async def resolve_dispute(
+    conn: AsyncConnection,
+    *,
+    trade_id: str | uuid.UUID,
+    resolved_by: str | uuid.UUID,
+    resolution: str,
+) -> tuple[sa.engine.Row, sa.engine.Row, sa.engine.Row]:
+    """Resolve an open dispute.
+
+    ``resolution`` must be ``'release'`` or ``'refund'``.
+
+    * ``release``: debit buyer wallet, credit seller wallet, transfer tokens to
+      buyer, set escrow to ``released``, trade to ``settled``.
+    * ``refund``: return locked tokens to seller, set escrow to ``refunded``,
+      trade to ``settled``.
+
+    Returns ``(dispute_row, trade_row, escrow_row)`` reflecting the final state.
+    """
+    if resolution not in ("release", "refund"):
+        raise ValueError("invalid_resolution")
+
+    now = _utc_now()
+    trade_id_uuid = _as_uuid(trade_id)
+
+    try:
+        # Load trade
+        trade_result = await conn.execute(
+            sa.select(trades_table).where(trades_table.c.id == trade_id_uuid)
+        )
+        trade_row = trade_result.fetchone()
+        if trade_row is None or _row_value(trade_row, "status") != "disputed":
+            raise LookupError("trade_not_found_or_state_conflict")
+
+        # Load escrow
+        escrow_result = await conn.execute(
+            sa.select(escrows_table).where(escrows_table.c.trade_id == trade_id_uuid)
+        )
+        escrow_row = escrow_result.fetchone()
+        if escrow_row is None or _row_value(escrow_row, "status") != "disputed":
+            raise LookupError("escrow_not_found_or_state_conflict")
+
+        # Load orders to identify buyer and seller
+        buy_order_result = await conn.execute(
+            sa.select(orders_table).where(
+                orders_table.c.id == _as_uuid(_row_value(trade_row, "buy_order_id"))
+            )
+        )
+        buy_order = buy_order_result.fetchone()
+        sell_order_result = await conn.execute(
+            sa.select(orders_table).where(
+                orders_table.c.id == _as_uuid(_row_value(trade_row, "sell_order_id"))
+            )
+        )
+        sell_order = sell_order_result.fetchone()
+        if buy_order is None or sell_order is None:
+            raise LookupError("orders_not_found")
+
+        buyer_id = _row_value(buy_order, "user_id")
+        seller_id = _row_value(sell_order, "user_id")
+        token_id = _row_value(trade_row, "token_id")
+        quantity = int(_row_value(trade_row, "quantity", 0))
+        total_sat = int(_row_value(trade_row, "total_sat", 0))
+
+        if resolution == "release":
+            # Transfer value: buyer pays sats, seller delivers tokens to buyer
+            buyer_wallet = await get_wallet_by_user_id(conn, buyer_id)
+            seller_wallet = await get_wallet_by_user_id(conn, seller_id)
+            if buyer_wallet is None or seller_wallet is None:
+                raise LookupError("wallet_not_found")
+
+            await debit_wallet_balance(conn, wallet_row=buyer_wallet, amount_sat=total_sat)
+            await credit_wallet_balance(conn, wallet_row=seller_wallet, amount_sat=total_sat)
+            await increment_token_balance(conn, user_id=buyer_id, token_id=token_id, quantity=quantity)
+
+            new_escrow_status = "released"
+        else:
+            # Refund: return locked tokens to seller (tokens were decremented at escrow creation)
+            await increment_token_balance(conn, user_id=seller_id, token_id=token_id, quantity=quantity)
+            new_escrow_status = "refunded"
+
+        # Update escrow status
+        escrow_update_result = await conn.execute(
+            sa.update(escrows_table)
+            .where(escrows_table.c.trade_id == trade_id_uuid)
+            .where(escrows_table.c.status == "disputed")
+            .values(status=new_escrow_status, updated_at=now)
+            .returning(escrows_table)
+        )
+        escrow_row = escrow_update_result.fetchone()
+        if escrow_row is None:
+            raise LookupError("escrow_update_failed")
+
+        # Update trade status
+        trade_update_result = await conn.execute(
+            sa.update(trades_table)
+            .where(trades_table.c.id == trade_id_uuid)
+            .values(status="settled", settled_at=now)
+            .returning(trades_table)
+        )
+        trade_row = trade_update_result.fetchone()
+        if trade_row is None:
+            raise LookupError("trade_update_failed")
+
+        # Resolve the dispute record
+        dispute_update_result = await conn.execute(
+            sa.update(disputes_table)
+            .where(disputes_table.c.trade_id == trade_id_uuid)
+            .where(disputes_table.c.status == "open")
+            .values(
+                status="resolved",
+                resolution=resolution,
+                resolved_by=_as_uuid(resolved_by),
+                resolved_at=now,
+                updated_at=now,
+            )
+            .returning(disputes_table)
+        )
+        dispute_row = dispute_update_result.fetchone()
+        if dispute_row is None:
+            raise LookupError("dispute_not_found_or_already_resolved")
+
+        await conn.commit()
+    except Exception:
+        await conn.rollback()
+        raise
+
+    return dispute_row, trade_row, escrow_row

--- a/services/marketplace/main.py
+++ b/services/marketplace/main.py
@@ -33,6 +33,7 @@ from marketplace.db import (
     create_order,
     create_trade_escrow,
     find_best_match,
+    get_dispute_by_trade_id,
     get_escrow_by_trade_id,
     get_last_trade_price_for_token,
     get_order_by_id,
@@ -47,11 +48,17 @@ from marketplace.db import (
     list_orders,
     list_trades,
     mark_escrow_funded,
+    open_dispute,
     process_escrow_signature,
+    resolve_dispute,
 )
 from marketplace.schemas import (
     CancelOrderResponse,
     CancelledOrderOut,
+    DisputeOpenRequest,
+    DisputeOut,
+    DisputeResolveRequest,
+    DisputeResponse,
     EscrowOut,
     EscrowResponse,
     EscrowSignRequest,
@@ -196,6 +203,20 @@ def _escrow_out(row: object) -> EscrowOut:
         release_txid=_row_value(row, "release_txid"),
         status=_row_value(row, "status"),
         expires_at=_row_value(row, "expires_at"),
+    )
+
+
+def _dispute_out(row: object) -> DisputeOut:
+    return DisputeOut(
+        id=_row_value(row, "id"),
+        trade_id=_row_value(row, "trade_id"),
+        opened_by=_row_value(row, "opened_by"),
+        reason=_row_value(row, "reason"),
+        status=_row_value(row, "status"),
+        resolution=_row_value(row, "resolution"),
+        resolved_by=_row_value(row, "resolved_by"),
+        resolved_at=_row_value(row, "resolved_at"),
+        created_at=_row_value(row, "created_at"),
     )
 
 
@@ -899,6 +920,129 @@ async def get_trade_history(
         trades=[_trade_out(row) for row in page],
         next_cursor=next_cursor,
     ).model_dump(mode="json")
+
+
+@app.post(
+    "/trades/{trade_id}/dispute",
+    status_code=status.HTTP_201_CREATED,
+    response_model=DisputeResponse,
+)
+async def create_dispute(
+    trade_id: uuid.UUID,
+    body: DisputeOpenRequest,
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    async with _runtime_engine().connect() as conn:
+        trade_row = await get_trade_by_id(conn, trade_id)
+        if trade_row is None:
+            raise _trade_not_found_error()
+
+        buy_order = await get_order_by_id(conn, _row_value(trade_row, "buy_order_id"))
+        sell_order = await get_order_by_id(conn, _row_value(trade_row, "sell_order_id"))
+        if buy_order is None or sell_order is None:
+            raise _trade_not_found_error()
+
+        participant_ids = {
+            str(_row_value(buy_order, "user_id")),
+            str(_row_value(sell_order, "user_id")),
+        }
+        if principal.id not in participant_ids:
+            raise ContractError(
+                code="forbidden",
+                message="You are not a participant in this trade.",
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        if _row_value(trade_row, "status") != "escrowed":
+            raise ContractError(
+                code="trade_state_conflict",
+                message="Only escrowed trades can be disputed.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        existing_dispute = await get_dispute_by_trade_id(conn, trade_id)
+        if existing_dispute is not None:
+            raise ContractError(
+                code="dispute_already_exists",
+                message="A dispute has already been opened for this trade.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            dispute_row = await open_dispute(
+                conn,
+                trade_id=trade_id,
+                opened_by=principal.id,
+                reason=body.reason,
+            )
+        except LookupError as exc:
+            raise ContractError(
+                code="trade_state_conflict",
+                message="Trade or escrow is not in a disputable state.",
+                status_code=status.HTTP_409_CONFLICT,
+            ) from exc
+
+    return DisputeResponse(dispute=_dispute_out(dispute_row)).model_dump(mode="json")
+
+
+@app.post(
+    "/trades/{trade_id}/dispute/resolve",
+    response_model=DisputeResponse,
+)
+async def resolve_trade_dispute(
+    trade_id: uuid.UUID,
+    body: DisputeResolveRequest,
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    if principal.role != "admin":
+        raise ContractError(
+            code="forbidden",
+            message="Only admins can resolve disputes.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+    async with _runtime_engine().connect() as conn:
+        trade_row = await get_trade_by_id(conn, trade_id)
+        if trade_row is None:
+            raise _trade_not_found_error()
+
+        if _row_value(trade_row, "status") != "disputed":
+            raise ContractError(
+                code="trade_state_conflict",
+                message="Trade is not in a disputed state.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        existing_dispute = await get_dispute_by_trade_id(conn, trade_id)
+        if existing_dispute is None:
+            raise ContractError(
+                code="dispute_not_found",
+                message="No open dispute found for this trade.",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        if _row_value(existing_dispute, "status") != "open":
+            raise ContractError(
+                code="dispute_already_resolved",
+                message="This dispute has already been resolved.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            dispute_row, _trade_row, _escrow_row = await resolve_dispute(
+                conn,
+                trade_id=trade_id,
+                resolved_by=principal.id,
+                resolution=body.resolution,
+            )
+        except LookupError as exc:
+            raise ContractError(
+                code="resolution_conflict",
+                message="Could not apply resolution due to a state conflict.",
+                status_code=status.HTTP_409_CONFLICT,
+            ) from exc
+
+    return DisputeResponse(dispute=_dispute_out(dispute_row)).model_dump(mode="json")
 
 
 if __name__ == "__main__":

--- a/services/marketplace/schemas.py
+++ b/services/marketplace/schemas.py
@@ -11,6 +11,8 @@ OrderSide = Literal["buy", "sell"]
 OrderStatus = Literal["open", "partially_filled", "filled", "cancelled"]
 TradeStatus = Literal["pending", "escrowed", "settled", "disputed"]
 EscrowStatus = Literal["created", "funded", "released", "refunded", "disputed"]
+DisputeStatus = Literal["open", "resolved"]
+DisputeResolution = Literal["refund", "release"]
 
 
 class OrderCreateRequest(BaseModel):
@@ -96,3 +98,27 @@ class EscrowResponse(BaseModel):
 
 class EscrowSignRequest(BaseModel):
     partial_signature: str = Field(min_length=1)
+
+
+class DisputeOpenRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=2000)
+
+
+class DisputeResolveRequest(BaseModel):
+    resolution: DisputeResolution
+
+
+class DisputeOut(BaseModel):
+    id: UUID
+    trade_id: UUID
+    opened_by: UUID
+    reason: str
+    status: DisputeStatus
+    resolution: DisputeResolution | None = None
+    resolved_by: UUID | None = None
+    resolved_at: datetime | None = None
+    created_at: datetime
+
+
+class DisputeResponse(BaseModel):
+    dispute: DisputeOut

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1272,3 +1272,620 @@ def test_get_trade_history_paginates_and_filters_by_token(client):
                 "settled_at",
             }
             assert trade["token_id"] != str(other_token_id)
+
+
+# ---------------------------------------------------------------------------
+# Dispute helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dispute(
+    *,
+    trade_id: uuid.UUID,
+    opened_by: uuid.UUID,
+    reason: str = "Payment not received",
+    status: str = "open",
+    resolution: str | None = None,
+    resolved_by: uuid.UUID | None = None,
+    resolved_at: datetime | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(tz=timezone.utc)
+    return {
+        "id": uuid.uuid4(),
+        "trade_id": trade_id,
+        "opened_by": opened_by,
+        "reason": reason,
+        "status": status,
+        "resolution": resolution,
+        "resolved_by": resolved_by,
+        "resolved_at": resolved_at,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dispute API tests
+# ---------------------------------------------------------------------------
+
+
+def test_open_dispute_allows_trade_participant_to_dispute_escrowed_trade(client):
+    app_client, _, settings = client
+    fake_buyer = _make_fake_user(role="user")
+    access_token = _issue_access_token(fake_buyer, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    buy_order = _make_order(
+        user_id=fake_buyer.id,
+        token_id=token_id,
+        side="buy",
+        quantity=5,
+        price_sat=100_000,
+    )
+    sell_order = _make_order(
+        user_id=uuid.uuid4(),
+        token_id=token_id,
+        side="sell",
+        quantity=5,
+        price_sat=100_000,
+    )
+    trade_row = _make_trade(
+        token_id=token_id,
+        buy_order_id=buy_order["id"],
+        sell_order_id=sell_order["id"],
+        quantity=5,
+        price_sat=100_000,
+        status="escrowed",
+        settled_at=None,
+    )
+    dispute_row = _make_dispute(trade_id=trade_row["id"], opened_by=fake_buyer.id)
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=fake_buyer)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=trade_row)),
+        patch(
+            "services.marketplace.main.get_order_by_id",
+            AsyncMock(side_effect=[buy_order, sell_order]),
+        ),
+        patch("services.marketplace.main.get_dispute_by_trade_id", AsyncMock(return_value=None)),
+        patch("services.marketplace.main.open_dispute", AsyncMock(return_value=dispute_row)) as open_dispute_mock,
+    ):
+        response = app_client.post(
+            f"/trades/{trade_row['id']}/dispute",
+            headers=_auth_headers(access_token),
+            json={"reason": "Payment not received"},
+        )
+
+    assert response.status_code == 201
+    body = response.json()["dispute"]
+    assert body["trade_id"] == str(trade_row["id"])
+    assert body["opened_by"] == str(fake_buyer.id)
+    assert body["reason"] == "Payment not received"
+    assert body["status"] == "open"
+    assert body["resolution"] is None
+    open_dispute_mock.assert_awaited_once_with(
+        ANY,
+        trade_id=trade_row["id"],
+        opened_by=str(fake_buyer.id),
+        reason="Payment not received",
+    )
+
+
+def test_open_dispute_rejects_non_participant(client):
+    app_client, _, settings = client
+    outsider = _make_fake_user(role="user")
+    access_token = _issue_access_token(outsider, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    buy_order = _make_order(
+        user_id=uuid.uuid4(),
+        token_id=token_id,
+        side="buy",
+        quantity=5,
+        price_sat=100_000,
+    )
+    sell_order = _make_order(
+        user_id=uuid.uuid4(),
+        token_id=token_id,
+        side="sell",
+        quantity=5,
+        price_sat=100_000,
+    )
+    trade_row = _make_trade(
+        token_id=token_id,
+        buy_order_id=buy_order["id"],
+        sell_order_id=sell_order["id"],
+        quantity=5,
+        price_sat=100_000,
+        status="escrowed",
+        settled_at=None,
+    )
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=outsider)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=trade_row)),
+        patch(
+            "services.marketplace.main.get_order_by_id",
+            AsyncMock(side_effect=[buy_order, sell_order]),
+        ),
+    ):
+        response = app_client.post(
+            f"/trades/{trade_row['id']}/dispute",
+            headers=_auth_headers(access_token),
+            json={"reason": "Trying to dispute someone else's trade"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden"
+
+
+def test_open_dispute_rejects_trade_not_in_escrowed_state(client):
+    app_client, _, settings = client
+    fake_buyer = _make_fake_user(role="user")
+    access_token = _issue_access_token(fake_buyer, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    buy_order = _make_order(
+        user_id=fake_buyer.id,
+        token_id=token_id,
+        side="buy",
+        quantity=5,
+        price_sat=100_000,
+    )
+    sell_order = _make_order(
+        user_id=uuid.uuid4(),
+        token_id=token_id,
+        side="sell",
+        quantity=5,
+        price_sat=100_000,
+    )
+    pending_trade = _make_trade(
+        token_id=token_id,
+        buy_order_id=buy_order["id"],
+        sell_order_id=sell_order["id"],
+        quantity=5,
+        price_sat=100_000,
+        status="pending",
+        settled_at=None,
+    )
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=fake_buyer)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=pending_trade)),
+        patch(
+            "services.marketplace.main.get_order_by_id",
+            AsyncMock(side_effect=[buy_order, sell_order]),
+        ),
+    ):
+        response = app_client.post(
+            f"/trades/{pending_trade['id']}/dispute",
+            headers=_auth_headers(access_token),
+            json={"reason": "Should not work"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "trade_state_conflict"
+
+
+def test_open_dispute_rejects_duplicate_dispute(client):
+    app_client, _, settings = client
+    fake_buyer = _make_fake_user(role="user")
+    access_token = _issue_access_token(fake_buyer, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    buy_order = _make_order(
+        user_id=fake_buyer.id,
+        token_id=token_id,
+        side="buy",
+        quantity=5,
+        price_sat=100_000,
+    )
+    sell_order = _make_order(
+        user_id=uuid.uuid4(),
+        token_id=token_id,
+        side="sell",
+        quantity=5,
+        price_sat=100_000,
+    )
+    trade_row = _make_trade(
+        token_id=token_id,
+        buy_order_id=buy_order["id"],
+        sell_order_id=sell_order["id"],
+        quantity=5,
+        price_sat=100_000,
+        status="escrowed",
+        settled_at=None,
+    )
+    existing_dispute = _make_dispute(trade_id=trade_row["id"], opened_by=fake_buyer.id)
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=fake_buyer)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=trade_row)),
+        patch(
+            "services.marketplace.main.get_order_by_id",
+            AsyncMock(side_effect=[buy_order, sell_order]),
+        ),
+        patch("services.marketplace.main.get_dispute_by_trade_id", AsyncMock(return_value=existing_dispute)),
+    ):
+        response = app_client.post(
+            f"/trades/{trade_row['id']}/dispute",
+            headers=_auth_headers(access_token),
+            json={"reason": "Duplicate attempt"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "dispute_already_exists"
+
+
+def test_resolve_dispute_release_settles_trade_and_transfers_value(client):
+    app_client, _, settings = client
+    admin_user = _make_fake_user(role="admin")
+    access_token = _issue_access_token(admin_user, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    trade_id = uuid.uuid4()
+    disputed_trade = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=uuid.uuid4(),
+            sell_order_id=uuid.uuid4(),
+            quantity=5,
+            price_sat=100_000,
+            status="disputed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "disputed",
+    }
+    open_dispute_row = _make_dispute(trade_id=trade_id, opened_by=uuid.uuid4())
+    resolved_trade = {**disputed_trade, "status": "settled"}
+    resolved_escrow = _make_escrow(trade_id=trade_id, locked_amount_sat=500_000, status="released")
+    resolved_dispute = {
+        **open_dispute_row,
+        "status": "resolved",
+        "resolution": "release",
+        "resolved_by": admin_user.id,
+        "resolved_at": datetime.now(tz=timezone.utc),
+    }
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=admin_user)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=disputed_trade)),
+        patch("services.marketplace.main.get_dispute_by_trade_id", AsyncMock(return_value=open_dispute_row)),
+        patch(
+            "services.marketplace.main.resolve_dispute",
+            AsyncMock(return_value=(resolved_dispute, resolved_trade, resolved_escrow)),
+        ) as resolve_dispute_mock,
+    ):
+        response = app_client.post(
+            f"/trades/{trade_id}/dispute/resolve",
+            headers=_auth_headers(access_token),
+            json={"resolution": "release"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()["dispute"]
+    assert body["status"] == "resolved"
+    assert body["resolution"] == "release"
+    assert body["resolved_by"] == str(admin_user.id)
+    resolve_dispute_mock.assert_awaited_once_with(
+        ANY,
+        trade_id=trade_id,
+        resolved_by=str(admin_user.id),
+        resolution="release",
+    )
+
+
+def test_resolve_dispute_refund_sets_escrow_to_refunded(client):
+    app_client, _, settings = client
+    admin_user = _make_fake_user(role="admin")
+    access_token = _issue_access_token(admin_user, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    trade_id = uuid.uuid4()
+    disputed_trade = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=uuid.uuid4(),
+            sell_order_id=uuid.uuid4(),
+            quantity=5,
+            price_sat=100_000,
+            status="disputed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "disputed",
+    }
+    open_dispute_row = _make_dispute(trade_id=trade_id, opened_by=uuid.uuid4())
+    resolved_trade = {**disputed_trade, "status": "settled"}
+    refunded_escrow = _make_escrow(trade_id=trade_id, locked_amount_sat=500_000, status="refunded")
+    resolved_dispute = {
+        **open_dispute_row,
+        "status": "resolved",
+        "resolution": "refund",
+        "resolved_by": admin_user.id,
+        "resolved_at": datetime.now(tz=timezone.utc),
+    }
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=admin_user)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=disputed_trade)),
+        patch("services.marketplace.main.get_dispute_by_trade_id", AsyncMock(return_value=open_dispute_row)),
+        patch(
+            "services.marketplace.main.resolve_dispute",
+            AsyncMock(return_value=(resolved_dispute, resolved_trade, refunded_escrow)),
+        ) as resolve_dispute_mock,
+    ):
+        response = app_client.post(
+            f"/trades/{trade_id}/dispute/resolve",
+            headers=_auth_headers(access_token),
+            json={"resolution": "refund"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()["dispute"]
+    assert body["status"] == "resolved"
+    assert body["resolution"] == "refund"
+    resolve_dispute_mock.assert_awaited_once_with(
+        ANY,
+        trade_id=trade_id,
+        resolved_by=str(admin_user.id),
+        resolution="refund",
+    )
+
+
+def test_resolve_dispute_rejects_non_admin(client):
+    app_client, _, settings = client
+    regular_user = _make_fake_user(role="user")
+    access_token = _issue_access_token(regular_user, settings.jwt_secret)
+    trade_id = uuid.uuid4()
+
+    with patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=regular_user)):
+        response = app_client.post(
+            f"/trades/{trade_id}/dispute/resolve",
+            headers=_auth_headers(access_token),
+            json={"resolution": "release"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden"
+
+
+def test_resolve_dispute_rejects_non_disputed_trade(client):
+    app_client, _, settings = client
+    admin_user = _make_fake_user(role="admin")
+    access_token = _issue_access_token(admin_user, settings.jwt_secret)
+    token_id = uuid.uuid4()
+    trade_id = uuid.uuid4()
+    escrowed_trade = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=uuid.uuid4(),
+            sell_order_id=uuid.uuid4(),
+            quantity=5,
+            price_sat=100_000,
+            status="escrowed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "escrowed",
+    }
+
+    with (
+        patch("services.marketplace.main.get_user_by_id", AsyncMock(return_value=admin_user)),
+        patch("services.marketplace.main.get_trade_by_id", AsyncMock(return_value=escrowed_trade)),
+    ):
+        response = app_client.post(
+            f"/trades/{trade_id}/dispute/resolve",
+            headers=_auth_headers(access_token),
+            json={"resolution": "release"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "trade_state_conflict"
+
+
+# ---------------------------------------------------------------------------
+# Dispute DB unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_open_dispute_db_updates_trade_and_escrow_status(marketplace_settings):
+    with patch.dict(os.environ, marketplace_settings, clear=False):
+        for module_name in ("services.marketplace.db", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+
+        import services.marketplace.db as marketplace_db
+
+    trade_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    opener_id = uuid.uuid4()
+    trade_row = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=uuid.uuid4(),
+            sell_order_id=uuid.uuid4(),
+            quantity=5,
+            price_sat=100_000,
+            status="disputed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+    }
+    escrow_row = _make_escrow(trade_id=trade_id, locked_amount_sat=500_000, status="disputed")
+    dispute_row = _make_dispute(trade_id=trade_id, opened_by=opener_id)
+
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(
+        side_effect=[
+            _FetchOneResult(trade_row),   # UPDATE trades SET status='disputed'
+            _FetchOneResult(escrow_row),  # UPDATE escrows SET status='disputed'
+            _FetchOneResult(dispute_row), # INSERT INTO disputes
+        ]
+    )
+    fake_conn.commit = AsyncMock()
+    fake_conn.rollback = AsyncMock()
+
+    result = asyncio.run(
+        marketplace_db.open_dispute(
+            fake_conn,
+            trade_id=trade_id,
+            opened_by=opener_id,
+            reason="Documentation incomplete",
+        )
+    )
+
+    assert result == dispute_row
+    assert fake_conn.execute.await_count == 3
+    fake_conn.commit.assert_awaited_once()
+    fake_conn.rollback.assert_not_awaited()
+
+
+def test_resolve_dispute_db_release_debits_buyer_and_transfers_tokens(marketplace_settings):
+    with patch.dict(os.environ, marketplace_settings, clear=False):
+        for module_name in ("services.marketplace.db", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+
+        import services.marketplace.db as marketplace_db
+
+    trade_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    buyer_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    buy_order = _make_order(user_id=buyer_id, token_id=token_id, side="buy", quantity=5, price_sat=100_000)
+    sell_order = _make_order(user_id=seller_id, token_id=token_id, side="sell", quantity=5, price_sat=100_000)
+    trade_row = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=buy_order["id"],
+            sell_order_id=sell_order["id"],
+            quantity=5,
+            price_sat=100_000,
+            status="disputed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "disputed",
+    }
+    escrow_row = _make_escrow(trade_id=trade_id, locked_amount_sat=500_000, status="disputed")
+    settled_trade = {**trade_row, "status": "settled"}
+    released_escrow = {**escrow_row, "status": "released"}
+    resolved_dispute = _make_dispute(
+        trade_id=trade_id,
+        opened_by=buyer_id,
+        status="resolved",
+        resolution="release",
+    )
+    admin_id = uuid.uuid4()
+    buyer_wallet = _make_wallet(buyer_id, onchain=2_000_000, lightning=0)
+    seller_wallet = _make_wallet(seller_id, onchain=0, lightning=0)
+
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(
+        side_effect=[
+            _FetchOneResult(trade_row),       # SELECT trade
+            _FetchOneResult(escrow_row),      # SELECT escrow
+            _FetchOneResult(buy_order),       # SELECT buy order
+            _FetchOneResult(sell_order),      # SELECT sell order
+            _FetchOneResult(released_escrow), # UPDATE escrow status
+            _FetchOneResult(settled_trade),   # UPDATE trade status
+            _FetchOneResult(resolved_dispute),# UPDATE dispute status
+        ]
+    )
+    fake_conn.commit = AsyncMock()
+    fake_conn.rollback = AsyncMock()
+
+    with (
+        patch.object(marketplace_db, "get_wallet_by_user_id", AsyncMock(side_effect=[buyer_wallet, seller_wallet])),
+        patch.object(marketplace_db, "debit_wallet_balance", AsyncMock()) as debit_mock,
+        patch.object(marketplace_db, "credit_wallet_balance", AsyncMock()) as credit_mock,
+        patch.object(marketplace_db, "increment_token_balance", AsyncMock()) as increment_mock,
+    ):
+        dispute_result, trade_result, escrow_result = asyncio.run(
+            marketplace_db.resolve_dispute(
+                fake_conn,
+                trade_id=trade_id,
+                resolved_by=admin_id,
+                resolution="release",
+            )
+        )
+
+    assert dispute_result == resolved_dispute
+    assert trade_result == settled_trade
+    assert escrow_result == released_escrow
+    debit_mock.assert_awaited_once_with(fake_conn, wallet_row=buyer_wallet, amount_sat=500_000)
+    credit_mock.assert_awaited_once_with(fake_conn, wallet_row=seller_wallet, amount_sat=500_000)
+    increment_mock.assert_awaited_once_with(fake_conn, user_id=buyer_id, token_id=token_id, quantity=5)
+    fake_conn.commit.assert_awaited_once()
+    fake_conn.rollback.assert_not_awaited()
+
+
+def test_resolve_dispute_db_refund_returns_tokens_to_seller(marketplace_settings):
+    with patch.dict(os.environ, marketplace_settings, clear=False):
+        for module_name in ("services.marketplace.db", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+
+        import services.marketplace.db as marketplace_db
+
+    trade_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    buyer_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    buy_order = _make_order(user_id=buyer_id, token_id=token_id, side="buy", quantity=8, price_sat=50_000)
+    sell_order = _make_order(user_id=seller_id, token_id=token_id, side="sell", quantity=8, price_sat=50_000)
+    trade_row = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=buy_order["id"],
+            sell_order_id=sell_order["id"],
+            quantity=8,
+            price_sat=50_000,
+            status="disputed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "disputed",
+    }
+    escrow_row = _make_escrow(trade_id=trade_id, locked_amount_sat=400_000, status="disputed")
+    settled_trade = {**trade_row, "status": "settled"}
+    refunded_escrow = {**escrow_row, "status": "refunded"}
+    resolved_dispute = _make_dispute(
+        trade_id=trade_id,
+        opened_by=buyer_id,
+        status="resolved",
+        resolution="refund",
+    )
+    admin_id = uuid.uuid4()
+
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(
+        side_effect=[
+            _FetchOneResult(trade_row),       # SELECT trade
+            _FetchOneResult(escrow_row),      # SELECT escrow
+            _FetchOneResult(buy_order),       # SELECT buy order
+            _FetchOneResult(sell_order),      # SELECT sell order
+            _FetchOneResult(refunded_escrow), # UPDATE escrow status
+            _FetchOneResult(settled_trade),   # UPDATE trade status
+            _FetchOneResult(resolved_dispute),# UPDATE dispute status
+        ]
+    )
+    fake_conn.commit = AsyncMock()
+    fake_conn.rollback = AsyncMock()
+
+    with (
+        patch.object(marketplace_db, "increment_token_balance", AsyncMock()) as increment_mock,
+        patch.object(marketplace_db, "debit_wallet_balance", AsyncMock()) as debit_mock,
+        patch.object(marketplace_db, "credit_wallet_balance", AsyncMock()) as credit_mock,
+    ):
+        dispute_result, trade_result, escrow_result = asyncio.run(
+            marketplace_db.resolve_dispute(
+                fake_conn,
+                trade_id=trade_id,
+                resolved_by=admin_id,
+                resolution="refund",
+            )
+        )
+
+    assert dispute_result == resolved_dispute
+    assert trade_result == settled_trade
+    assert escrow_result == refunded_escrow
+    # Token quantity returned to seller, no wallet debits
+    increment_mock.assert_awaited_once_with(fake_conn, user_id=seller_id, token_id=token_id, quantity=8)
+    debit_mock.assert_not_awaited()
+    credit_mock.assert_not_awaited()
+    fake_conn.commit.assert_awaited_once()
+    fake_conn.rollback.assert_not_awaited()


### PR DESCRIPTION
# Feature: Formal Dispute Path for Escrowed Trades

## Overview

Implements a formal dispute path for escrowed trades, allowing users to initiate disputes and admins to resolve them with refund or release outcomes.

## Features

- **Dispute Initiation**
  - Trade participants (buyer or seller) can open a dispute on an escrowed trade, providing a reason.
  - Only one dispute can be open per trade.
  - Trade and escrow statuses are atomically updated to `disputed`.

- **Admin Resolution**
  - Admins can resolve disputes with a `refund` (return tokens to seller) or `release` (release funds to seller, transfer tokens to buyer).
  - Trade and escrow statuses are updated accordingly (`settled`, `released`, or `refunded`).
  - Dispute records store resolution type, resolver, and timestamp.

- **API Endpoints**
  - `POST /trades/{trade_id}/dispute` — Open a dispute (participant only)
  - `POST /trades/{trade_id}/dispute/resolve` — Resolve a dispute (admin only)

- **Database**
  - New `disputes` table with status, resolution, and audit fields.
  - Alembic migration included.

- **Tests**
  - 11 new tests covering all dispute paths, including API and DB logic.

## Acceptance Criteria

- Users can open a dispute with a reason against an escrowed trade.
- Admins can resolve a dispute with a supported resolution type.
- The final escrow and trade status reflects the selected resolution.

## Commits

- Add disputes table to database metadata and Alembic migration 0007
- Add DisputeOpenRequest, DisputeResolveRequest, DisputeOut and DisputeResponse Pydantic schemas
- Add get_dispute_by_trade_id, open_dispute and resolve_dispute DB functions with release and refund paths
- Add POST /trades/{trade_id}/dispute and POST /trades/{trade_id}/dispute/resolve endpoints
- Add 11 dispute tests covering open, resolve, non-participant, state guard and DB unit paths

---

**All dispute tests pass. No regressions introduced.**