### PR TITLE
Track settled trade fees in the treasury ledger

### DIFF
--- a/services/marketplace/db.py
+++ b/services/marketplace/db.py
@@ -18,6 +18,7 @@ from common.db.metadata import nostr_identities as nostr_identities_table
 from common.db.metadata import orders as orders_table
 from common.db.metadata import token_balances as token_balances_table
 from common.db.metadata import tokens as tokens_table
+from common.db.metadata import treasury as treasury_table
 from common.db.metadata import trades as trades_table
 from common.db.metadata import users as users_table
 from common.db.metadata import wallets as wallets_table
@@ -240,6 +241,94 @@ async def list_trades(
     stmt = stmt.order_by(order_column.desc(), trades_table.c.id.desc())
     result = await conn.execute(stmt)
     return result.fetchall()
+
+
+async def get_latest_treasury_entry(conn: AsyncConnection) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(treasury_table)
+        .order_by(treasury_table.c.created_at.desc(), treasury_table.c.id.desc())
+        .limit(1)
+    )
+    return result.fetchone()
+
+
+def _treasury_balance_delta(*, entry_type: str, amount_sat: int) -> int:
+    if amount_sat <= 0:
+        raise ValueError("treasury_amount_must_be_positive")
+
+    if entry_type == "fee_income":
+        return amount_sat
+    if entry_type == "disbursement":
+        return -amount_sat
+    if entry_type == "adjustment":
+        return amount_sat
+    raise ValueError("invalid_treasury_entry_type")
+
+
+async def create_treasury_entry(
+    conn: AsyncConnection,
+    *,
+    entry_type: str,
+    amount_sat: int,
+    description: str | None = None,
+    source_trade_id: str | uuid.UUID | None = None,
+    created_at: datetime | None = None,
+) -> sa.engine.Row:
+    latest_entry = await get_latest_treasury_entry(conn)
+    current_balance = int(_row_value(latest_entry, "balance_after_sat", 0))
+    balance_after_sat = current_balance + _treasury_balance_delta(
+        entry_type=entry_type,
+        amount_sat=amount_sat,
+    )
+    timestamp = created_at or _utc_now()
+
+    result = await conn.execute(
+        sa.insert(treasury_table)
+        .values(
+            id=uuid.uuid4(),
+            source_trade_id=None if source_trade_id is None else _as_uuid(source_trade_id),
+            type=entry_type,
+            amount_sat=amount_sat,
+            balance_after_sat=balance_after_sat,
+            description=description,
+            created_at=timestamp,
+        )
+        .returning(treasury_table)
+    )
+    row = result.fetchone()
+    assert row is not None
+    return row
+
+
+async def record_trade_fee_income(
+    conn: AsyncConnection,
+    *,
+    trade_row: object,
+) -> sa.engine.Row | None:
+    fee_sat = int(_row_value(trade_row, "fee_sat", 0))
+    if fee_sat <= 0:
+        return None
+
+    trade_id = _as_uuid(_row_value(trade_row, "id"))
+    existing_result = await conn.execute(
+        sa.select(treasury_table)
+        .where(treasury_table.c.type == "fee_income")
+        .where(treasury_table.c.source_trade_id == trade_id)
+        .limit(1)
+    )
+    existing_entry = existing_result.fetchone()
+    if existing_entry is not None:
+        return existing_entry
+
+    settled_at = _row_value(trade_row, "settled_at")
+    return await create_treasury_entry(
+        conn,
+        entry_type="fee_income",
+        amount_sat=fee_sat,
+        source_trade_id=trade_id,
+        description=f"Fee income from trade {trade_id}",
+        created_at=settled_at if isinstance(settled_at, datetime) else None,
+    )
 
 
 async def get_trade_by_id(
@@ -643,6 +732,7 @@ async def settle_trade(
         )
         trade_row = result.fetchone()
         assert trade_row is not None
+        await record_trade_fee_income(conn, trade_row=trade_row)
         await conn.commit()
     except Exception:
         await conn.rollback()
@@ -761,15 +851,17 @@ async def process_escrow_signature(
             token_id = _row_value(trade_row, "token_id")
             quantity = int(_row_value(trade_row, "quantity", 0))
             total_sat = int(_row_value(trade_row, "total_sat", 0))
+            fee_sat = int(_row_value(trade_row, "fee_sat", 0))
 
             buyer_wallet = await get_wallet_by_user_id(conn, buyer_id)
             seller_wallet = await get_wallet_by_user_id(conn, seller_id)
             if buyer_wallet is None or seller_wallet is None:
                 raise LookupError("wallet_not_found")
 
-            await debit_wallet_balance(conn, wallet_row=buyer_wallet, amount_sat=total_sat)
+            await debit_wallet_balance(conn, wallet_row=buyer_wallet, amount_sat=total_sat + fee_sat)
             await credit_wallet_balance(conn, wallet_row=seller_wallet, amount_sat=total_sat)
             await increment_token_balance(conn, user_id=buyer_id, token_id=token_id, quantity=quantity)
+            await record_trade_fee_income(conn, trade_row=trade_row)
         else:
             escrow_result = await conn.execute(
                 sa.update(escrows_table)
@@ -936,6 +1028,7 @@ async def resolve_dispute(
         token_id = _row_value(trade_row, "token_id")
         quantity = int(_row_value(trade_row, "quantity", 0))
         total_sat = int(_row_value(trade_row, "total_sat", 0))
+        fee_sat = int(_row_value(trade_row, "fee_sat", 0))
 
         if resolution == "release":
             # Transfer value: buyer pays sats, seller delivers tokens to buyer
@@ -944,7 +1037,7 @@ async def resolve_dispute(
             if buyer_wallet is None or seller_wallet is None:
                 raise LookupError("wallet_not_found")
 
-            await debit_wallet_balance(conn, wallet_row=buyer_wallet, amount_sat=total_sat)
+            await debit_wallet_balance(conn, wallet_row=buyer_wallet, amount_sat=total_sat + fee_sat)
             await credit_wallet_balance(conn, wallet_row=seller_wallet, amount_sat=total_sat)
             await increment_token_balance(conn, user_id=buyer_id, token_id=token_id, quantity=quantity)
 
@@ -976,6 +1069,8 @@ async def resolve_dispute(
         trade_row = trade_update_result.fetchone()
         if trade_row is None:
             raise LookupError("trade_update_failed")
+        if resolution == "release":
+            await record_trade_fee_income(conn, trade_row=trade_row)
 
         # Resolve the dispute record
         dispute_update_result = await conn.execute(

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -88,6 +88,7 @@ def _make_trade(
     sell_order_id: uuid.UUID,
     quantity: int,
     price_sat: int,
+    fee_sat: int = 0,
     status: str = "settled",
     created_at: datetime | None = None,
     settled_at: datetime | None = None,
@@ -101,7 +102,7 @@ def _make_trade(
         "quantity": quantity,
         "price_sat": price_sat,
         "total_sat": quantity * price_sat,
-        "fee_sat": 0,
+        "fee_sat": fee_sat,
         "status": status,
         "created_at": now,
         "settled_at": settled_at if settled_at is not None or status != "settled" else now,
@@ -135,6 +136,26 @@ def _make_escrow(
         "expires_at": expires_at or now,
         "created_at": now,
         "updated_at": now,
+    }
+
+
+def _make_treasury_entry(
+    *,
+    amount_sat: int,
+    balance_after_sat: int,
+    source_trade_id: uuid.UUID | None = None,
+    entry_type: str = "fee_income",
+    description: str | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(tz=timezone.utc)
+    return {
+        "id": uuid.uuid4(),
+        "source_trade_id": source_trade_id,
+        "type": entry_type,
+        "amount_sat": amount_sat,
+        "balance_after_sat": balance_after_sat,
+        "description": description,
+        "created_at": now,
     }
 
 
@@ -867,6 +888,7 @@ def test_get_escrow_details_refreshes_funding_status_and_emits_event(client):
             "multisig_address": funded_escrow["multisig_address"],
             "locked_amount_sat": 1_000_000,
             "funding_txid": "cd" * 32,
+            "release_txid": None,
             "status": "funded",
             "expires_at": funded_escrow["expires_at"].isoformat().replace("+00:00", "Z"),
         }
@@ -924,6 +946,7 @@ def test_settle_trade_synchronizes_wallet_and_token_balances(marketplace_setting
         sell_order_id=sell_order["id"],
         quantity=10,
         price_sat=100_000,
+        fee_sat=5_000,
     )
     fake_conn = AsyncMock()
     fake_conn.execute = AsyncMock(return_value=_FetchOneResult(trade_row))
@@ -936,6 +959,7 @@ def test_settle_trade_synchronizes_wallet_and_token_balances(marketplace_setting
         patch.object(marketplace_db, "decrement_token_balance", AsyncMock()) as decrement_balance_mock,
         patch.object(marketplace_db, "increment_token_balance", AsyncMock()) as increment_balance_mock,
         patch.object(marketplace_db, "apply_order_fill", AsyncMock()) as apply_fill_mock,
+        patch.object(marketplace_db, "record_trade_fee_income", AsyncMock()) as record_fee_mock,
     ):
         result = asyncio.run(
             marketplace_db.settle_trade(
@@ -944,6 +968,7 @@ def test_settle_trade_synchronizes_wallet_and_token_balances(marketplace_setting
                 sell_order=sell_order,
                 quantity=10,
                 price_sat=100_000,
+                fee_sat=5_000,
             )
         )
 
@@ -951,7 +976,7 @@ def test_settle_trade_synchronizes_wallet_and_token_balances(marketplace_setting
     debit_wallet_mock.assert_awaited_once_with(
         fake_conn,
         wallet_row=buyer_wallet,
-        amount_sat=1_000_000,
+        amount_sat=1_005_000,
     )
     credit_wallet_mock.assert_awaited_once_with(
         fake_conn,
@@ -971,7 +996,151 @@ def test_settle_trade_synchronizes_wallet_and_token_balances(marketplace_setting
         quantity=10,
     )
     assert apply_fill_mock.await_count == 2
+    record_fee_mock.assert_awaited_once_with(fake_conn, trade_row=trade_row)
     fake_conn.commit.assert_awaited_once()
+
+
+def test_record_trade_fee_income_creates_traceable_running_ledger_entry(marketplace_settings):
+    with patch.dict(os.environ, marketplace_settings, clear=False):
+        for module_name in (
+            "services.marketplace.db",
+            "common",
+            "common.config",
+        ):
+            sys.modules.pop(module_name, None)
+
+        import services.marketplace.db as marketplace_db
+
+    trade_row = _make_trade(
+        token_id=uuid.uuid4(),
+        buy_order_id=uuid.uuid4(),
+        sell_order_id=uuid.uuid4(),
+        quantity=4,
+        price_sat=125_000,
+        fee_sat=7_500,
+    )
+    latest_entry = _make_treasury_entry(amount_sat=3_000, balance_after_sat=23_000)
+    inserted_entry = _make_treasury_entry(
+        amount_sat=7_500,
+        balance_after_sat=30_500,
+        source_trade_id=trade_row["id"],
+        description=f"Fee income from trade {trade_row['id']}",
+    )
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(
+        side_effect=[
+            _FetchOneResult(None),
+            _FetchOneResult(latest_entry),
+            _FetchOneResult(inserted_entry),
+        ]
+    )
+
+    result = asyncio.run(
+        marketplace_db.record_trade_fee_income(
+            fake_conn,
+            trade_row=trade_row,
+        )
+    )
+
+    assert result == inserted_entry
+    insert_stmt = fake_conn.execute.await_args_list[2].args[0]
+    insert_params = insert_stmt.compile().params
+    assert insert_params["type"] == "fee_income"
+    assert insert_params["amount_sat"] == 7_500
+    assert insert_params["balance_after_sat"] == 30_500
+    assert insert_params["source_trade_id"] == trade_row["id"]
+    assert str(trade_row["id"]) in insert_params["description"]
+
+
+def test_process_escrow_signature_release_extracts_fee_and_records_treasury_income(marketplace_settings):
+    with patch.dict(os.environ, marketplace_settings, clear=False):
+        for module_name in (
+            "services.marketplace.db",
+            "common",
+            "common.config",
+        ):
+            sys.modules.pop(module_name, None)
+
+        import services.marketplace.db as marketplace_db
+
+    buyer_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    trade_id = uuid.uuid4()
+    buy_order = _make_order(user_id=buyer_id, token_id=token_id, side="buy", quantity=3, price_sat=200_000)
+    sell_order = _make_order(user_id=seller_id, token_id=token_id, side="sell", quantity=3, price_sat=200_000)
+    trade_row = {
+        **_make_trade(
+            token_id=token_id,
+            buy_order_id=buy_order["id"],
+            sell_order_id=sell_order["id"],
+            quantity=3,
+            price_sat=200_000,
+            fee_sat=12_000,
+            status="escrowed",
+            settled_at=None,
+        ),
+        "id": trade_id,
+        "status": "escrowed",
+    }
+    escrow_row = _make_escrow(trade_id=trade_id, locked_amount_sat=600_000, funding_txid="ab" * 32, status="funded")
+    settled_at = datetime(2026, 4, 14, 18, 0, tzinfo=timezone.utc)
+    released_escrow = {
+        **escrow_row,
+        "status": "released",
+        "release_txid": "cd" * 32,
+        "collected_signatures": {
+            "buyer": "11" * 32,
+            "platform": "33" * 32,
+        },
+    }
+    settled_trade = {
+        **trade_row,
+        "status": "settled",
+        "settled_at": settled_at,
+    }
+    buyer_wallet = _make_wallet(buyer_id, onchain=1_000_000, lightning=0)
+    seller_wallet = _make_wallet(seller_id, onchain=0, lightning=0)
+
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(
+        side_effect=[
+            _FetchOneResult(released_escrow),
+            _FetchOneResult(settled_trade),
+        ]
+    )
+    fake_conn.commit = AsyncMock()
+    fake_conn.rollback = AsyncMock()
+
+    with (
+        patch.object(marketplace_db, "_generate_release_txid", return_value="cd" * 32),
+        patch.object(marketplace_db, "get_wallet_by_user_id", AsyncMock(side_effect=[buyer_wallet, seller_wallet])),
+        patch.object(marketplace_db, "debit_wallet_balance", AsyncMock()) as debit_mock,
+        patch.object(marketplace_db, "credit_wallet_balance", AsyncMock()) as credit_mock,
+        patch.object(marketplace_db, "increment_token_balance", AsyncMock()) as increment_mock,
+        patch.object(marketplace_db, "record_trade_fee_income", AsyncMock()) as record_fee_mock,
+    ):
+        trade_result, escrow_result = asyncio.run(
+            marketplace_db.process_escrow_signature(
+                fake_conn,
+                escrow_row=escrow_row,
+                trade_row=trade_row,
+                buy_order=buy_order,
+                sell_order=sell_order,
+                signer_role="buyer",
+                signature="11" * 32,
+                platform_signature="33" * 32,
+            )
+        )
+
+    assert trade_result == settled_trade
+    assert escrow_result == released_escrow
+    debit_mock.assert_awaited_once_with(fake_conn, wallet_row=buyer_wallet, amount_sat=612_000)
+    credit_mock.assert_awaited_once_with(fake_conn, wallet_row=seller_wallet, amount_sat=600_000)
+    increment_mock.assert_awaited_once_with(fake_conn, user_id=buyer_id, token_id=token_id, quantity=3)
+    record_fee_mock.assert_awaited_once_with(fake_conn, trade_row=settled_trade)
+    fake_conn.commit.assert_awaited_once()
+    fake_conn.rollback.assert_not_awaited()
 
 
 def test_apply_order_fill_caps_filled_quantity_at_total_quantity(marketplace_settings):
@@ -1755,6 +1924,7 @@ def test_resolve_dispute_db_release_debits_buyer_and_transfers_tokens(marketplac
             sell_order_id=sell_order["id"],
             quantity=5,
             price_sat=100_000,
+            fee_sat=10_000,
             status="disputed",
             settled_at=None,
         ),
@@ -1794,6 +1964,7 @@ def test_resolve_dispute_db_release_debits_buyer_and_transfers_tokens(marketplac
         patch.object(marketplace_db, "debit_wallet_balance", AsyncMock()) as debit_mock,
         patch.object(marketplace_db, "credit_wallet_balance", AsyncMock()) as credit_mock,
         patch.object(marketplace_db, "increment_token_balance", AsyncMock()) as increment_mock,
+        patch.object(marketplace_db, "record_trade_fee_income", AsyncMock()) as record_fee_mock,
     ):
         dispute_result, trade_result, escrow_result = asyncio.run(
             marketplace_db.resolve_dispute(
@@ -1807,9 +1978,10 @@ def test_resolve_dispute_db_release_debits_buyer_and_transfers_tokens(marketplac
     assert dispute_result == resolved_dispute
     assert trade_result == settled_trade
     assert escrow_result == released_escrow
-    debit_mock.assert_awaited_once_with(fake_conn, wallet_row=buyer_wallet, amount_sat=500_000)
+    debit_mock.assert_awaited_once_with(fake_conn, wallet_row=buyer_wallet, amount_sat=510_000)
     credit_mock.assert_awaited_once_with(fake_conn, wallet_row=seller_wallet, amount_sat=500_000)
     increment_mock.assert_awaited_once_with(fake_conn, user_id=buyer_id, token_id=token_id, quantity=5)
+    record_fee_mock.assert_awaited_once_with(fake_conn, trade_row=settled_trade)
     fake_conn.commit.assert_awaited_once()
     fake_conn.rollback.assert_not_awaited()
 


### PR DESCRIPTION
## Track settled trade fees in the treasury ledger

This PR wires fee extraction into the marketplace settlement flow so platform fees from settled trades are recorded in the treasury ledger and reflected in a running balance.

### What changed
- Added treasury ledger persistence for `fee_income` entries tied to the source trade.
- Updated all settlement paths to record fees when a trade reaches `settled`.
- Kept the treasury balance as a running `balance_after_sat` ledger value.
- Extended marketplace tests to cover fee recording, traceability, and balance updates.

### Verification
- `python -m pytest tests/test_marketplace.py`
- `python -m compileall services/marketplace/db.py tests/test_marketplace.py`

### Notes
- This implementation uses the existing `trade.fee_sat` field as the fee source.
- The change is intentionally scoped to the acceptance criteria only.
