### PR TITLE
Feat/courses enrollment

### DIFF
--- a/services/education/db.py
+++ b/services/education/db.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.db.metadata import courses as courses_table
+from common.db.metadata import enrollments as enrollments_table
+from common.db.metadata import users as users_table
+
+
+def _as_uuid(value: str | uuid.UUID) -> uuid.UUID:
+    return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _normalize_progress(value: float | Decimal) -> Decimal:
+    return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+async def get_user_by_id(
+    conn: AsyncConnection,
+    user_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(users_table).where(users_table.c.id == _as_uuid(user_id))
+    )
+    return result.fetchone()
+
+
+async def list_courses(
+    conn: AsyncConnection,
+    *,
+    category: str | None = None,
+    difficulty: str | None = None,
+) -> list[sa.engine.Row]:
+    stmt = sa.select(courses_table).where(courses_table.c.is_published.is_(True))
+
+    if category is not None:
+        stmt = stmt.where(courses_table.c.category == category)
+    if difficulty is not None:
+        stmt = stmt.where(courses_table.c.difficulty == difficulty)
+
+    stmt = stmt.order_by(courses_table.c.created_at.desc(), courses_table.c.id.desc())
+    result = await conn.execute(stmt)
+    return result.fetchall()
+
+
+async def get_course_by_id(
+    conn: AsyncConnection,
+    course_id: str | uuid.UUID,
+    *,
+    published_only: bool = True,
+) -> sa.engine.Row | None:
+    stmt = sa.select(courses_table).where(courses_table.c.id == _as_uuid(course_id))
+    if published_only:
+        stmt = stmt.where(courses_table.c.is_published.is_(True))
+
+    result = await conn.execute(stmt)
+    return result.fetchone()
+
+
+async def get_enrollment_by_id(
+    conn: AsyncConnection,
+    enrollment_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(enrollments_table).where(enrollments_table.c.id == _as_uuid(enrollment_id))
+    )
+    return result.fetchone()
+
+
+async def get_enrollment_by_user_course(
+    conn: AsyncConnection,
+    *,
+    user_id: str | uuid.UUID,
+    course_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(enrollments_table)
+        .where(enrollments_table.c.user_id == _as_uuid(user_id))
+        .where(enrollments_table.c.course_id == _as_uuid(course_id))
+    )
+    return result.fetchone()
+
+
+async def create_enrollment(
+    conn: AsyncConnection,
+    *,
+    user_id: str | uuid.UUID,
+    course_id: str | uuid.UUID,
+) -> sa.engine.Row:
+    now = _utc_now()
+    result = await conn.execute(
+        sa.insert(enrollments_table)
+        .values(
+            id=uuid.uuid4(),
+            user_id=_as_uuid(user_id),
+            course_id=_as_uuid(course_id),
+            progress=_normalize_progress(0),
+            enrolled_at=now,
+            completed_at=None,
+        )
+        .returning(enrollments_table)
+    )
+    row = result.fetchone()
+    await conn.commit()
+    assert row is not None
+    return row
+
+
+async def update_enrollment_progress(
+    conn: AsyncConnection,
+    *,
+    enrollment_id: str | uuid.UUID,
+    user_id: str | uuid.UUID,
+    progress: float | Decimal,
+) -> sa.engine.Row | None:
+    normalized_progress = _normalize_progress(progress)
+    completed_at = _utc_now() if normalized_progress >= Decimal("100.00") else None
+    result = await conn.execute(
+        sa.update(enrollments_table)
+        .where(enrollments_table.c.id == _as_uuid(enrollment_id))
+        .where(enrollments_table.c.user_id == _as_uuid(user_id))
+        .values(
+            progress=normalized_progress,
+            completed_at=completed_at,
+        )
+        .returning(enrollments_table)
+    )
+    row = result.fetchone()
+    await conn.commit()
+    return row

--- a/services/education/main.py
+++ b/services/education/main.py
@@ -1,17 +1,371 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 import sys
+from typing import Any
+import uuid
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Query, Request, Security, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 import uvicorn
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from auth.jwt_utils import decode_token
 from common import get_readiness_payload, get_settings
+from education.db import (
+    create_enrollment,
+    get_course_by_id,
+    get_enrollment_by_id,
+    get_enrollment_by_user_course,
+    get_user_by_id,
+    list_courses,
+    update_enrollment_progress,
+)
+from education.schemas import (
+    CourseDetailOut,
+    CourseDetailResponse,
+    CourseListResponse,
+    CourseOut,
+    EnrollmentOut,
+    EnrollmentProgressUpdateRequest,
+    EnrollmentResponse,
+)
+
 
 settings = get_settings(service_name="education", default_port=8004)
+_bearer_scheme = HTTPBearer(auto_error=False)
+_engine: AsyncEngine | object | None = None
 
-app = FastAPI(title="Education Service")
+
+class ContractError(Exception):
+    def __init__(self, *, code: str, message: str, status_code: int) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AuthenticatedPrincipal:
+    id: str
+    role: str
+
+
+def _make_async_url(sync_url: str) -> str:
+    url = sync_url
+    for prefix in ("postgresql://", "postgres://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+def _runtime_engine() -> AsyncEngine | object:
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(_make_async_url(settings.database_url), pool_pre_ping=True)
+    return _engine
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    engine = _runtime_engine()
+    yield
+    await engine.dispose()
+
+
+def _error(code: str, message: str, status_code: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code, "message": message}},
+    )
+
+
+def _jwt_secret() -> str:
+    return settings.jwt_secret or "dev-secret-change-me"
+
+
+def _normalize_uuid_claim(value: object) -> str | None:
+    try:
+        return str(uuid.UUID(str(value)))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _row_value(row: object, key: str, default: Any = None) -> Any:
+    if row is None:
+        return default
+    if isinstance(row, dict):
+        return row.get(key, default)
+
+    mapping = getattr(row, "_mapping", None)
+    if mapping is not None and key in mapping:
+        return mapping[key]
+
+    if hasattr(row, key):
+        return getattr(row, key)
+
+    try:
+        return row[key]
+    except (KeyError, TypeError, IndexError):
+        return default
+
+
+def _progress_number(value: object) -> float:
+    if isinstance(value, Decimal):
+        return float(value)
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _course_out(row: object) -> CourseOut:
+    return CourseOut(
+        id=str(_row_value(row, "id")),
+        title=str(_row_value(row, "title")),
+        description=str(_row_value(row, "description")),
+        category=str(_row_value(row, "category")),
+        difficulty=str(_row_value(row, "difficulty")),
+    )
+
+
+def _course_detail_out(row: object) -> CourseDetailOut:
+    return CourseDetailOut(
+        **_course_out(row).model_dump(),
+        content_url=str(_row_value(row, "content_url")),
+    )
+
+
+def _enrollment_out(row: object) -> EnrollmentOut:
+    return EnrollmentOut(
+        id=str(_row_value(row, "id")),
+        course_id=str(_row_value(row, "course_id")),
+        progress=_progress_number(_row_value(row, "progress")),
+        enrolled_at=_row_value(row, "enrolled_at"),
+        completed_at=_row_value(row, "completed_at"),
+    )
+
+
+def _build_course_page(
+    rows: list[object],
+    *,
+    cursor: str | None,
+    limit: int,
+) -> tuple[list[object], str | None]:
+    start_index = 0
+
+    if cursor is not None:
+        try:
+            cursor_uuid = str(uuid.UUID(cursor))
+        except ValueError as exc:
+            raise ContractError(
+                code="invalid_cursor",
+                message="Cursor must be a valid course UUID.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            ) from exc
+
+        for index, row in enumerate(rows):
+            if str(_row_value(row, "id")) == cursor_uuid:
+                start_index = index + 1
+                break
+        else:
+            raise ContractError(
+                code="invalid_cursor",
+                message="Cursor does not match a course in this result set.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+    page = rows[start_index:start_index + limit]
+    next_cursor = str(_row_value(page[-1], "id")) if start_index + limit < len(rows) and page else None
+    return page, next_cursor
+
+
+def _course_not_found_error() -> ContractError:
+    return ContractError(
+        code="course_not_found",
+        message="Course not found.",
+        status_code=status.HTTP_404_NOT_FOUND,
+    )
+
+
+def _enrollment_not_found_error() -> ContractError:
+    return ContractError(
+        code="enrollment_not_found",
+        message="Enrollment not found.",
+        status_code=status.HTTP_404_NOT_FOUND,
+    )
+
+
+def _invalid_access_token_error() -> ContractError:
+    return ContractError(
+        code="invalid_token",
+        message="Access token is invalid or expired.",
+        status_code=status.HTTP_401_UNAUTHORIZED,
+    )
+
+
+app = FastAPI(title="Education Service", lifespan=_lifespan)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return _error(
+        code="validation_error",
+        message="Request payload failed validation.",
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    )
+
+
+@app.exception_handler(ContractError)
+async def contract_exception_handler(request: Request, exc: ContractError):
+    return _error(exc.code, exc.message, exc.status_code)
+
+
+async def _get_current_principal(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
+) -> AuthenticatedPrincipal:
+    if credentials is None:
+        raise ContractError(
+            code="authentication_required",
+            message="Authentication is required.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    try:
+        claims = decode_token(
+            credentials.credentials,
+            _jwt_secret(),
+            expected_type="access",
+        )
+    except JWTError as exc:
+        raise _invalid_access_token_error() from exc
+
+    user_id = _normalize_uuid_claim(claims.get("sub"))
+    role = str(claims.get("role") or "user")
+    if user_id is None:
+        raise _invalid_access_token_error()
+
+    async with _runtime_engine().connect() as conn:
+        row = await get_user_by_id(conn, user_id)
+
+    if row is None or _row_value(row, "deleted_at") is not None:
+        raise _invalid_access_token_error()
+
+    return AuthenticatedPrincipal(id=user_id, role=role)
+
+
+@app.get("/courses", response_model=CourseListResponse)
+async def get_courses(
+    category: str | None = Query(default=None, pattern="^(bitcoin|finance|programming|entrepreneurship)$"),
+    difficulty: str | None = Query(default=None, pattern="^(beginner|intermediate|advanced)$"),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    async with _runtime_engine().connect() as conn:
+        rows = await list_courses(
+            conn,
+            category=category,
+            difficulty=difficulty,
+        )
+
+    page, next_cursor = _build_course_page(rows, cursor=cursor, limit=limit)
+    return CourseListResponse(
+        courses=[_course_out(row) for row in page],
+        next_cursor=next_cursor,
+    ).model_dump(mode="json")
+
+
+@app.get("/courses/{course_id}", response_model=CourseDetailResponse)
+async def get_course(course_id: uuid.UUID):
+    async with _runtime_engine().connect() as conn:
+        row = await get_course_by_id(conn, course_id)
+
+    if row is None:
+        raise _course_not_found_error()
+
+    return CourseDetailResponse(course=_course_detail_out(row)).model_dump(mode="json")
+
+
+@app.post(
+    "/courses/{course_id}/enroll",
+    status_code=status.HTTP_201_CREATED,
+    response_model=EnrollmentResponse,
+)
+async def enroll_in_course(
+    course_id: uuid.UUID,
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    async with _runtime_engine().connect() as conn:
+        course_row = await get_course_by_id(conn, course_id)
+        if course_row is None:
+            raise _course_not_found_error()
+
+        existing_enrollment = await get_enrollment_by_user_course(
+            conn,
+            user_id=principal.id,
+            course_id=course_id,
+        )
+        if existing_enrollment is not None:
+            raise ContractError(
+                code="enrollment_exists",
+                message="You are already enrolled in this course.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            enrollment_row = await create_enrollment(
+                conn,
+                user_id=principal.id,
+                course_id=course_id,
+            )
+        except IntegrityError as exc:
+            raise ContractError(
+                code="enrollment_exists",
+                message="You are already enrolled in this course.",
+                status_code=status.HTTP_409_CONFLICT,
+            ) from exc
+
+    return EnrollmentResponse(enrollment=_enrollment_out(enrollment_row)).model_dump(mode="json")
+
+
+@app.patch("/enrollments/{enrollment_id}", response_model=EnrollmentResponse)
+async def patch_enrollment(
+    enrollment_id: uuid.UUID,
+    body: EnrollmentProgressUpdateRequest,
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+):
+    async with _runtime_engine().connect() as conn:
+        enrollment_row = await get_enrollment_by_id(conn, enrollment_id)
+        if enrollment_row is None:
+            raise _enrollment_not_found_error()
+
+        if str(_row_value(enrollment_row, "user_id")) != principal.id:
+            raise ContractError(
+                code="forbidden",
+                message="You do not have permission to access this resource.",
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        updated_row = await update_enrollment_progress(
+            conn,
+            enrollment_id=enrollment_id,
+            user_id=principal.id,
+            progress=body.progress,
+        )
+
+    if updated_row is None:
+        raise _enrollment_not_found_error()
+
+    return EnrollmentResponse(enrollment=_enrollment_out(updated_row)).model_dump(mode="json")
+
 
 @app.get("/health")
 async def health():
@@ -27,6 +381,7 @@ async def ready():
     payload = get_readiness_payload(settings)
     status_code = 200 if payload["status"] == "ready" else 503
     return JSONResponse(status_code=status_code, content=payload)
+
 
 if __name__ == "__main__":
     uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/education/requirements.txt
+++ b/services/education/requirements.txt
@@ -1,3 +1,6 @@
 fastapi
 uvicorn
 pydantic-settings
+sqlalchemy
+asyncpg
+python-jose[cryptography]

--- a/services/education/schemas.py
+++ b/services/education/schemas.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+CourseCategory = Literal["bitcoin", "finance", "programming", "entrepreneurship"]
+CourseDifficulty = Literal["beginner", "intermediate", "advanced"]
+
+
+def _strip_and_require_text(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("Value must not be blank.")
+    return normalized
+
+
+class CourseOut(BaseModel):
+    id: str
+    title: str
+    description: str
+    category: CourseCategory
+    difficulty: CourseDifficulty
+
+
+class CourseDetailOut(CourseOut):
+    content_url: str
+
+
+class CourseListResponse(BaseModel):
+    courses: list[CourseOut]
+    next_cursor: str | None
+
+
+class CourseDetailResponse(BaseModel):
+    course: CourseDetailOut
+
+
+class EnrollmentOut(BaseModel):
+    id: str
+    course_id: str
+    progress: float
+    enrolled_at: datetime
+    completed_at: datetime | None = None
+
+
+class EnrollmentResponse(BaseModel):
+    enrollment: EnrollmentOut
+
+
+class EnrollmentProgressUpdateRequest(BaseModel):
+    progress: float = Field(ge=0, le=100)
+
+    @field_validator("progress")
+    @classmethod
+    def _validate_progress(cls, value: float) -> float:
+        return float(value)

--- a/tests/test_education.py
+++ b/tests/test_education.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from decimal import Decimal
+import os
+import sys
+from typing import Any, NamedTuple
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.auth.jwt_utils import issue_token_pair
+
+
+class FakeUser(NamedTuple):
+    id: uuid.UUID
+    email: str
+    display_name: str
+    role: str
+    created_at: datetime
+    deleted_at: datetime | None
+
+
+class FakeCourse(NamedTuple):
+    id: uuid.UUID
+    title: str
+    description: str
+    content_url: str
+    category: str
+    difficulty: str
+    is_published: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class FakeEnrollment(NamedTuple):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    course_id: uuid.UUID
+    progress: Decimal
+    enrolled_at: datetime
+    completed_at: datetime | None
+
+
+class _FetchOneResult:
+    def __init__(self, row: object) -> None:
+        self._row = row
+
+    def fetchone(self) -> object:
+        return self._row
+
+
+def _make_fake_user(*, role: str = "user") -> FakeUser:
+    return FakeUser(
+        id=uuid.uuid4(),
+        email="learner@example.com",
+        display_name="Learner",
+        role=role,
+        created_at=datetime.now(tz=timezone.utc),
+        deleted_at=None,
+    )
+
+
+def _make_course(
+    *,
+    category: str = "bitcoin",
+    difficulty: str = "beginner",
+    created_at: datetime | None = None,
+) -> FakeCourse:
+    now = created_at or datetime.now(tz=timezone.utc)
+    return FakeCourse(
+        id=uuid.uuid4(),
+        title="Bitcoin Fundamentals",
+        description="Learn the basics of Bitcoin and self-custody.",
+        content_url="https://education.example.com/courses/bitcoin-fundamentals",
+        category=category,
+        difficulty=difficulty,
+        is_published=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_enrollment(
+    *,
+    user_id: uuid.UUID,
+    course_id: uuid.UUID,
+    progress: Decimal | str = Decimal("0.00"),
+    completed_at: datetime | None = None,
+) -> FakeEnrollment:
+    return FakeEnrollment(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        course_id=course_id,
+        progress=Decimal(str(progress)),
+        enrolled_at=datetime.now(tz=timezone.utc),
+        completed_at=completed_at,
+    )
+
+
+@pytest.fixture()
+def education_settings() -> dict[str, str]:
+    return {
+        "ENV_PROFILE": "local",
+        "WALLET_SERVICE_URL": "http://wallet:8001",
+        "TOKENIZATION_SERVICE_URL": "http://tokenization:8002",
+        "MARKETPLACE_SERVICE_URL": "http://marketplace:8003",
+        "EDUCATION_SERVICE_URL": "http://education:8004",
+        "NOSTR_SERVICE_URL": "http://nostr:8005",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DB": "testdb",
+        "POSTGRES_USER": "user",
+        "DATABASE_URL": "postgresql://user:pass@localhost/testdb",
+        "REDIS_URL": "redis://localhost:6379/0",
+        "BITCOIN_RPC_HOST": "localhost",
+        "BITCOIN_RPC_PORT": "18443",
+        "BITCOIN_RPC_USER": "bitcoin",
+        "BITCOIN_NETWORK": "regtest",
+        "LND_GRPC_HOST": "localhost",
+        "LND_GRPC_PORT": "10009",
+        "LND_MACAROON_PATH": "tests/fixtures/admin.macaroon",
+        "LND_TLS_CERT_PATH": "tests/fixtures/tls.cert",
+        "TAPD_GRPC_HOST": "localhost",
+        "TAPD_GRPC_PORT": "10029",
+        "TAPD_MACAROON_PATH": "tests/fixtures/tapd.macaroon",
+        "TAPD_TLS_CERT_PATH": "tests/fixtures/tapd.cert",
+        "NOSTR_RELAYS": "wss://relay.example.com",
+        "JWT_SECRET": "test-secret-key-for-education-tests",
+        "JWT_ACCESS_TOKEN_EXPIRE_MINUTES": "15",
+        "JWT_REFRESH_TOKEN_EXPIRE_DAYS": "7",
+        "TOTP_ISSUER": "Platform",
+        "LOG_LEVEL": "INFO",
+    }
+
+
+@pytest.fixture()
+def client(education_settings):
+    fake_conn = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield fake_conn
+
+    fake_engine = MagicMock()
+    fake_engine.connect = _fake_connect
+    fake_engine.dispose = AsyncMock()
+
+    with patch.dict(os.environ, education_settings, clear=False):
+        for module_name in (
+            "services.education.main",
+            "services.education.db",
+            "services.education.schemas",
+            "common",
+            "common.config",
+        ):
+            sys.modules.pop(module_name, None)
+
+        import services.education.main as education_main
+
+        education_main._engine = fake_engine
+        app = education_main.app
+        app.router.lifespan_context = None
+
+        yield TestClient(app, raise_server_exceptions=True), education_main.settings
+
+
+def _issue_access_token(user: FakeUser, secret: str) -> str:
+    return issue_token_pair(
+        user_id=str(user.id),
+        role=user.role,
+        wallet_id=None,
+        secret=secret,
+    ).access_token
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def test_public_users_can_list_courses(client):
+    app_client, _ = client
+    newest = _make_course(
+        category="bitcoin",
+        difficulty="beginner",
+        created_at=datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc),
+    )
+    older = _make_course(
+        category="bitcoin",
+        difficulty="beginner",
+        created_at=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
+    )
+    list_courses_mock = AsyncMock(return_value=[newest, older])
+
+    with patch("services.education.main.list_courses", list_courses_mock):
+        response = app_client.get("/courses?category=bitcoin&difficulty=beginner&limit=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["next_cursor"] == str(newest.id)
+    assert body["courses"] == [
+        {
+            "id": str(newest.id),
+            "title": newest.title,
+            "description": newest.description,
+            "category": newest.category,
+            "difficulty": newest.difficulty,
+        }
+    ]
+    list_courses_mock.assert_awaited_once_with(
+        ANY,
+        category="bitcoin",
+        difficulty="beginner",
+    )
+
+
+def test_public_users_can_view_course_details(client):
+    app_client, _ = client
+    course = _make_course()
+
+    with patch("services.education.main.get_course_by_id", AsyncMock(return_value=course)):
+        response = app_client.get(f"/courses/{course.id}")
+
+    assert response.status_code == 200
+    assert response.json()["course"] == {
+        "id": str(course.id),
+        "title": course.title,
+        "description": course.description,
+        "category": course.category,
+        "difficulty": course.difficulty,
+        "content_url": course.content_url,
+    }
+
+
+def test_authenticated_user_can_enroll_in_course(client):
+    app_client, settings = client
+    learner = _make_fake_user()
+    access_token = _issue_access_token(learner, settings.jwt_secret)
+    course = _make_course()
+    enrollment = _make_enrollment(user_id=learner.id, course_id=course.id)
+    create_enrollment_mock = AsyncMock(return_value=enrollment)
+
+    with (
+        patch("services.education.main.get_user_by_id", AsyncMock(return_value=learner)),
+        patch("services.education.main.get_course_by_id", AsyncMock(return_value=course)),
+        patch("services.education.main.get_enrollment_by_user_course", AsyncMock(return_value=None)),
+        patch("services.education.main.create_enrollment", create_enrollment_mock),
+    ):
+        response = app_client.post(
+            f"/courses/{course.id}/enroll",
+            headers=_auth_headers(access_token),
+        )
+
+    assert response.status_code == 201
+    assert response.json()["enrollment"] == {
+        "id": str(enrollment.id),
+        "course_id": str(course.id),
+        "progress": 0.0,
+        "enrolled_at": enrollment.enrolled_at.isoformat().replace("+00:00", "Z"),
+        "completed_at": None,
+    }
+    create_enrollment_mock.assert_awaited_once_with(
+        ANY,
+        user_id=str(learner.id),
+        course_id=course.id,
+    )
+
+
+def test_enrollment_is_unique_per_user_and_course(client):
+    app_client, settings = client
+    learner = _make_fake_user()
+    access_token = _issue_access_token(learner, settings.jwt_secret)
+    course = _make_course()
+    existing_enrollment = _make_enrollment(user_id=learner.id, course_id=course.id)
+
+    with (
+        patch("services.education.main.get_user_by_id", AsyncMock(return_value=learner)),
+        patch("services.education.main.get_course_by_id", AsyncMock(return_value=course)),
+        patch("services.education.main.get_enrollment_by_user_course", AsyncMock(return_value=existing_enrollment)),
+        patch("services.education.main.create_enrollment", AsyncMock()) as create_enrollment_mock,
+    ):
+        response = app_client.post(
+            f"/courses/{course.id}/enroll",
+            headers=_auth_headers(access_token),
+        )
+
+    assert response.status_code == 409
+    assert response.json()["error"] == {
+        "code": "enrollment_exists",
+        "message": "You are already enrolled in this course.",
+    }
+    create_enrollment_mock.assert_not_called()
+
+
+def test_authenticated_user_can_update_own_progress(client):
+    app_client, settings = client
+    learner = _make_fake_user()
+    access_token = _issue_access_token(learner, settings.jwt_secret)
+    course = _make_course()
+    existing_enrollment = _make_enrollment(user_id=learner.id, course_id=course.id, progress="20.00")
+    completed_at = datetime(2026, 4, 14, 15, 0, tzinfo=timezone.utc)
+    updated_enrollment = existing_enrollment._replace(
+        progress=Decimal("100.00"),
+        completed_at=completed_at,
+    )
+    update_progress_mock = AsyncMock(return_value=updated_enrollment)
+
+    with (
+        patch("services.education.main.get_user_by_id", AsyncMock(return_value=learner)),
+        patch("services.education.main.get_enrollment_by_id", AsyncMock(return_value=existing_enrollment)),
+        patch("services.education.main.update_enrollment_progress", update_progress_mock),
+    ):
+        response = app_client.patch(
+            f"/enrollments/{existing_enrollment.id}",
+            headers=_auth_headers(access_token),
+            json={"progress": 100},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["enrollment"] == {
+        "id": str(existing_enrollment.id),
+        "course_id": str(course.id),
+        "progress": 100.0,
+        "enrolled_at": existing_enrollment.enrolled_at.isoformat().replace("+00:00", "Z"),
+        "completed_at": "2026-04-14T15:00:00Z",
+    }
+    update_progress_mock.assert_awaited_once_with(
+        ANY,
+        enrollment_id=existing_enrollment.id,
+        user_id=str(learner.id),
+        progress=100.0,
+    )
+
+
+def test_progress_update_rejects_values_outside_0_to_100(client):
+    app_client, settings = client
+    learner = _make_fake_user()
+    access_token = _issue_access_token(learner, settings.jwt_secret)
+    existing_enrollment = _make_enrollment(user_id=learner.id, course_id=uuid.uuid4(), progress="20.00")
+
+    with (
+        patch("services.education.main.get_user_by_id", AsyncMock(return_value=learner)),
+        patch("services.education.main.get_enrollment_by_id", AsyncMock(return_value=existing_enrollment)),
+        patch("services.education.main.update_enrollment_progress", AsyncMock()) as update_progress_mock,
+    ):
+        response = app_client.patch(
+            f"/enrollments/{existing_enrollment.id}",
+            headers=_auth_headers(access_token),
+            json={"progress": 150},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"] == {
+        "code": "validation_error",
+        "message": "Request payload failed validation.",
+    }
+    update_progress_mock.assert_not_called()
+
+
+def test_progress_update_rejects_other_users_enrollment(client):
+    app_client, settings = client
+    learner = _make_fake_user()
+    other_user = _make_fake_user()
+    access_token = _issue_access_token(learner, settings.jwt_secret)
+    existing_enrollment = _make_enrollment(user_id=other_user.id, course_id=uuid.uuid4(), progress="20.00")
+
+    with (
+        patch("services.education.main.get_user_by_id", AsyncMock(return_value=learner)),
+        patch("services.education.main.get_enrollment_by_id", AsyncMock(return_value=existing_enrollment)),
+        patch("services.education.main.update_enrollment_progress", AsyncMock()) as update_progress_mock,
+    ):
+        response = app_client.patch(
+            f"/enrollments/{existing_enrollment.id}",
+            headers=_auth_headers(access_token),
+            json={"progress": 45.5},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"] == {
+        "code": "forbidden",
+        "message": "You do not have permission to access this resource.",
+    }
+    update_progress_mock.assert_not_called()
+
+
+def test_update_enrollment_progress_db_marks_completion(education_settings):
+    with patch.dict(os.environ, education_settings, clear=False):
+        for module_name in ("services.education.db", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+
+        import services.education.db as education_db
+
+    enrollment_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    updated_row = {
+        "id": enrollment_id,
+        "user_id": user_id,
+        "course_id": uuid.uuid4(),
+        "progress": Decimal("100.00"),
+        "enrolled_at": datetime.now(tz=timezone.utc),
+        "completed_at": datetime.now(tz=timezone.utc),
+    }
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(return_value=_FetchOneResult(updated_row))
+    fake_conn.commit = AsyncMock()
+
+    result = asyncio.run(
+        education_db.update_enrollment_progress(
+            fake_conn,
+            enrollment_id=enrollment_id,
+            user_id=user_id,
+            progress=100,
+        )
+    )
+
+    assert result == updated_row
+    fake_conn.commit.assert_awaited_once()
+
+
+def test_create_enrollment_db_commits_new_record(education_settings):
+    with patch.dict(os.environ, education_settings, clear=False):
+        for module_name in ("services.education.db", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+
+        import services.education.db as education_db
+
+    enrollment_row = {
+        "id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "course_id": uuid.uuid4(),
+        "progress": Decimal("0.00"),
+        "enrolled_at": datetime.now(tz=timezone.utc),
+        "completed_at": None,
+    }
+    fake_conn = AsyncMock()
+    fake_conn.execute = AsyncMock(return_value=_FetchOneResult(enrollment_row))
+    fake_conn.commit = AsyncMock()
+
+    result = asyncio.run(
+        education_db.create_enrollment(
+            fake_conn,
+            user_id=enrollment_row["user_id"],
+            course_id=enrollment_row["course_id"],
+        )
+    )
+
+    assert result == enrollment_row
+    fake_conn.commit.assert_awaited_once()


### PR DESCRIPTION
## Summary

This PR implements the education-service acceptance criteria for course discovery, enrollment, and progress tracking.

## What Changed

- Added public course catalog and course detail endpoints
- Added authenticated course enrollment and progress update endpoints
- Added education service schemas and DB helpers for courses and enrollments
- Added focused tests for public access, enrollment, duplicate-enrollment rejection, owner-only progress updates, and progress validation
- Added missing education service dependencies for database access and JWT authentication

## Acceptance Criteria

- [x] Public users can list and view courses.
- [x] Authenticated users can enroll in a course and update progress.
- [x] Enrollment uniqueness and progress validation rules are enforced.

## Testing

- `python -m pytest tests\test_education.py`
