### PR TITLE
Feat/issue 033 admin apis

### DIFF
--- a/services/admin/db.py
+++ b/services/admin/db.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.db.metadata import courses as courses_table
+from common.db.metadata import disputes as disputes_table
+from common.db.metadata import treasury as treasury_table
+from common.db.metadata import users as users_table
+
+
+def _as_uuid(value: str | uuid.UUID) -> uuid.UUID:
+    return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _row_value(row: object, key: str, default: object | None = None):
+    mapping = getattr(row, "_mapping", None)
+    if mapping is not None and key in mapping:
+        return mapping[key]
+    return getattr(row, key, default)
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+async def list_users(
+    conn: AsyncConnection,
+    *,
+    role: str | None = None,
+) -> list[sa.engine.Row]:
+    stmt = (
+        sa.select(users_table)
+        .where(users_table.c.deleted_at.is_(None))
+        .order_by(users_table.c.created_at.desc(), users_table.c.id.desc())
+    )
+    if role is not None:
+        stmt = stmt.where(users_table.c.role == role)
+    result = await conn.execute(stmt)
+    return result.fetchall()
+
+
+async def get_user_by_id(
+    conn: AsyncConnection,
+    user_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(users_table).where(users_table.c.id == _as_uuid(user_id))
+    )
+    return result.fetchone()
+
+
+async def update_user_role(
+    conn: AsyncConnection,
+    *,
+    user_id: str | uuid.UUID,
+    new_role: str,
+) -> sa.engine.Row | None:
+    """Update the role for a non-deleted user. Returns the updated row or None."""
+    now = _utc_now()
+    result = await conn.execute(
+        sa.update(users_table)
+        .where(users_table.c.id == _as_uuid(user_id))
+        .where(users_table.c.deleted_at.is_(None))
+        .values(role=new_role, updated_at=now)
+        .returning(users_table)
+    )
+    row = result.fetchone()
+    if row is None:
+        return None
+    await conn.commit()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Courses
+# ---------------------------------------------------------------------------
+
+async def create_course(
+    conn: AsyncConnection,
+    *,
+    title: str,
+    description: str,
+    content_url: str,
+    category: str,
+    difficulty: str,
+) -> sa.engine.Row:
+    now = _utc_now()
+    result = await conn.execute(
+        sa.insert(courses_table)
+        .values(
+            id=uuid.uuid4(),
+            title=title,
+            description=description,
+            content_url=content_url,
+            category=category,
+            difficulty=difficulty,
+            is_published=False,
+            created_at=now,
+            updated_at=now,
+        )
+        .returning(courses_table)
+    )
+    row = result.fetchone()
+    assert row is not None
+    await conn.commit()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Treasury
+# ---------------------------------------------------------------------------
+
+async def get_latest_treasury_entry(conn: AsyncConnection) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(treasury_table)
+        .order_by(treasury_table.c.created_at.desc(), treasury_table.c.id.desc())
+        .limit(1)
+    )
+    return result.fetchone()
+
+
+async def list_treasury_entries(
+    conn: AsyncConnection,
+    *,
+    limit: int = 50,
+    cursor_id: str | None = None,
+) -> list[sa.engine.Row]:
+    stmt = sa.select(treasury_table).order_by(
+        treasury_table.c.created_at.desc(), treasury_table.c.id.desc()
+    )
+    if cursor_id is not None:
+        # Cursor-based: entries older than (or equal-created-at with lower id) the cursor
+        cursor_row_result = await conn.execute(
+            sa.select(treasury_table).where(
+                treasury_table.c.id == _as_uuid(cursor_id)
+            )
+        )
+        cursor_row = cursor_row_result.fetchone()
+        if cursor_row is not None:
+            cursor_ts = _row_value(cursor_row, "created_at")
+            cursor_uuid = _row_value(cursor_row, "id")
+            stmt = stmt.where(
+                sa.or_(
+                    treasury_table.c.created_at < cursor_ts,
+                    sa.and_(
+                        treasury_table.c.created_at == cursor_ts,
+                        treasury_table.c.id < cursor_uuid,
+                    ),
+                )
+            )
+    result = await conn.execute(stmt.limit(limit))
+    return result.fetchall()
+
+
+async def disburse_treasury(
+    conn: AsyncConnection,
+    *,
+    amount_sat: int,
+    description: str,
+) -> sa.engine.Row:
+    """Insert a disbursement entry, decrementing the running balance."""
+    latest_entry = await get_latest_treasury_entry(conn)
+    current_balance = int(_row_value(latest_entry, "balance_after_sat", 0))
+    if current_balance < amount_sat:
+        raise ValueError("insufficient_treasury_balance")
+
+    balance_after_sat = current_balance - amount_sat
+    now = _utc_now()
+    result = await conn.execute(
+        sa.insert(treasury_table)
+        .values(
+            id=uuid.uuid4(),
+            source_trade_id=None,
+            type="disbursement",
+            amount_sat=amount_sat,
+            balance_after_sat=balance_after_sat,
+            description=description,
+            created_at=now,
+        )
+        .returning(treasury_table)
+    )
+    row = result.fetchone()
+    assert row is not None
+    await conn.commit()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Disputes
+# ---------------------------------------------------------------------------
+
+async def get_dispute_by_trade_id(
+    conn: AsyncConnection,
+    trade_id: str | uuid.UUID,
+) -> sa.engine.Row | None:
+    result = await conn.execute(
+        sa.select(disputes_table).where(
+            disputes_table.c.trade_id == _as_uuid(trade_id)
+        )
+    )
+    return result.fetchone()

--- a/services/admin/main.py
+++ b/services/admin/main.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import time
+from typing import Annotated
+import uuid
+
+from fastapi import Depends, FastAPI, Header, Query, Request, Security, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+import uvicorn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from auth.jwt_utils import decode_token
+from common import get_readiness_payload, get_settings
+from admin.db import (
+    create_course,
+    disburse_treasury,
+    get_dispute_by_trade_id,
+    get_user_by_id,
+    list_treasury_entries,
+    list_users,
+    update_user_role,
+)
+from admin.schemas import (
+    AdminDisputeResolveRequest,
+    CourseOut,
+    CourseResponse,
+    CreateCourseRequest,
+    DisputeOut,
+    DisputeResponse,
+    TreasuryDisburseRequest,
+    TreasuryDisburseResponse,
+    TreasuryEntryOut,
+    UpdateUserRoleRequest,
+    UserListResponse,
+    UserOut,
+)
+from marketplace.db import resolve_dispute
+
+
+settings = get_settings(service_name="admin", default_port=8006)
+_bearer_scheme = HTTPBearer(auto_error=False)
+_engine: AsyncEngine | object | None = None
+
+# ---------------------------------------------------------------------------
+# TOTP helpers (same implementation as marketplace)
+# ---------------------------------------------------------------------------
+
+_TOTP_DIGITS = 6
+_TOTP_PERIOD_SECONDS = 30
+
+
+def _generate_totp(secret: str, counter: int) -> str:
+    normalized = secret.strip().replace(" ", "").upper()
+    key = base64.b32decode(normalized, casefold=True)
+    digest = hmac.new(key, counter.to_bytes(8, "big"), hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    binary = int.from_bytes(digest[offset : offset + 4], "big") & 0x7FFFFFFF
+    return str(binary % (10**_TOTP_DIGITS)).zfill(_TOTP_DIGITS)
+
+
+def _verify_totp_code(secret: str, code: str) -> bool:
+    normalized = code.strip()
+    if not normalized.isdigit() or len(normalized) != _TOTP_DIGITS:
+        return False
+    counter = int(time.time() // _TOTP_PERIOD_SECONDS)
+    try:
+        return any(
+            hmac.compare_digest(_generate_totp(secret, counter + offset), normalized)
+            for offset in (-1, 0, 1)
+        )
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# App bootstrap
+# ---------------------------------------------------------------------------
+
+
+class ContractError(Exception):
+    def __init__(self, *, code: str, message: str, status_code: int) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AuthenticatedPrincipal:
+    id: str
+    role: str
+
+
+def _make_async_url(sync_url: str) -> str:
+    for prefix in ("postgresql://", "postgres://"):
+        if sync_url.startswith(prefix):
+            return "postgresql+asyncpg://" + sync_url[len(prefix):]
+    return sync_url
+
+
+def _runtime_engine() -> AsyncEngine | object:
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(
+            _make_async_url(settings.database_url), pool_pre_ping=True
+        )
+    return _engine
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _runtime_engine()
+    yield
+    await _runtime_engine().dispose()
+
+
+def _error(code: str, message: str, status_code: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code, "message": message}},
+    )
+
+
+def _row_value(row: object, key: str, default: object | None = None):
+    mapping = getattr(row, "_mapping", None)
+    if mapping is not None and key in mapping:
+        return mapping[key]
+    return getattr(row, key, default)
+
+
+def _aware_datetime(value) -> datetime | None:
+    if value is None:
+        return None
+    if hasattr(value, "tzinfo") and value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _jwt_secret() -> str:
+    return settings.jwt_secret or "dev-secret-change-me"
+
+
+def _normalize_uuid_claim(value: object) -> str | None:
+    try:
+        return str(uuid.UUID(str(value)))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Auth dependencies
+# ---------------------------------------------------------------------------
+
+
+async def _get_current_principal(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
+) -> AuthenticatedPrincipal:
+    if credentials is None:
+        raise ContractError(
+            code="authentication_required",
+            message="Authentication is required.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+    try:
+        claims = decode_token(
+            credentials.credentials,
+            _jwt_secret(),
+            expected_type="access",
+        )
+    except JWTError as exc:
+        raise ContractError(
+            code="invalid_token",
+            message="Access token is invalid or expired.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        ) from exc
+
+    user_id = _normalize_uuid_claim(claims.get("sub"))
+    role = claims.get("role")
+    if user_id is None or not isinstance(role, str):
+        raise ContractError(
+            code="invalid_token",
+            message="Access token is invalid or expired.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    async with _runtime_engine().connect() as conn:
+        row = await get_user_by_id(conn, user_id)
+
+    if row is None or _row_value(row, "deleted_at") is not None:
+        raise ContractError(
+            code="invalid_token",
+            message="Access token is invalid or expired.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    return AuthenticatedPrincipal(id=user_id, role=role)
+
+
+async def _require_admin(
+    principal: AuthenticatedPrincipal = Depends(_get_current_principal),
+) -> AuthenticatedPrincipal:
+    if principal.role != "admin":
+        raise ContractError(
+            code="forbidden",
+            message="Admin role is required.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+    return principal
+
+
+async def _check_2fa(conn: object, user_id: str, code: str | None) -> None:
+    """Verify 2FA code when the user has TOTP configured."""
+    user_row = await get_user_by_id(conn, user_id)
+    totp_secret = _row_value(user_row, "totp_secret") if user_row is not None else None
+    if not totp_secret:
+        return
+    if code is None:
+        raise ContractError(
+            code="2fa_required",
+            message="Two-factor authentication code is required.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+    if not _verify_totp_code(str(totp_secret), code):
+        raise ContractError(
+            code="2fa_invalid",
+            message="Invalid two-factor authentication code.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Row -> schema helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_out(row: object) -> UserOut:
+    return UserOut(
+        id=str(_row_value(row, "id")),
+        email=_row_value(row, "email"),
+        display_name=_row_value(row, "display_name"),
+        role=_row_value(row, "role"),
+        created_at=_aware_datetime(_row_value(row, "created_at")),
+    )
+
+
+def _course_out(row: object) -> CourseOut:
+    return CourseOut(
+        id=str(_row_value(row, "id")),
+        title=_row_value(row, "title"),
+        description=_row_value(row, "description"),
+        category=_row_value(row, "category"),
+        difficulty=_row_value(row, "difficulty"),
+        content_url=_row_value(row, "content_url"),
+    )
+
+
+def _treasury_entry_out(row: object) -> TreasuryEntryOut:
+    return TreasuryEntryOut(
+        id=str(_row_value(row, "id")),
+        type=_row_value(row, "type"),
+        amount_sat=int(_row_value(row, "amount_sat", 0)),
+        balance_after_sat=int(_row_value(row, "balance_after_sat", 0)),
+        reference_id=(
+            str(_row_value(row, "source_trade_id"))
+            if _row_value(row, "source_trade_id") is not None
+            else None
+        ),
+        description=_row_value(row, "description"),
+        created_at=_aware_datetime(_row_value(row, "created_at")),
+    )
+
+
+def _dispute_out(row: object) -> DisputeOut:
+    return DisputeOut(
+        id=str(_row_value(row, "id")),
+        trade_id=str(_row_value(row, "trade_id")),
+        opened_by=str(_row_value(row, "opened_by")),
+        reason=_row_value(row, "reason"),
+        status=_row_value(row, "status"),
+        resolution=_row_value(row, "resolution"),
+        resolved_by=(
+            str(_row_value(row, "resolved_by"))
+            if _row_value(row, "resolved_by") is not None
+            else None
+        ),
+        notes=None,
+        resolved_at=_aware_datetime(_row_value(row, "resolved_at")),
+        created_at=_aware_datetime(_row_value(row, "created_at")),
+        updated_at=_aware_datetime(_row_value(row, "updated_at")),
+    )
+
+
+def _build_user_page(
+    rows: list[object],
+    *,
+    cursor: str | None,
+    limit: int,
+) -> tuple[list[object], str | None]:
+    start_index = 0
+    if cursor is not None:
+        try:
+            cursor_uuid = str(uuid.UUID(cursor))
+        except ValueError as exc:
+            raise ContractError(
+                code="invalid_cursor",
+                message="Cursor must be a valid user UUID.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            ) from exc
+        for i, row in enumerate(rows):
+            if str(_row_value(row, "id")) == cursor_uuid:
+                start_index = i + 1
+                break
+        else:
+            raise ContractError(
+                code="invalid_cursor",
+                message="Cursor does not match a user in the result set.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+    page = rows[start_index : start_index + limit]
+    next_cursor = (
+        str(_row_value(page[-1], "id"))
+        if start_index + limit < len(rows) and page
+        else None
+    )
+    return page, next_cursor
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="Admin Service", lifespan=_lifespan)
+
+
+@app.exception_handler(ContractError)
+async def contract_exception_handler(request: Request, exc: ContractError):
+    return _error(exc.code, exc.message, exc.status_code)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return _error(
+        "validation_error",
+        "Request payload failed validation.",
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+    )
+
+
+@app.get("/health")
+async def health():
+    return {
+        "status": "ok",
+        "service": settings.service_name,
+        "env_profile": settings.env_profile,
+    }
+
+
+@app.get("/ready")
+async def ready():
+    payload = get_readiness_payload(settings)
+    status_code = 200 if payload["status"] == "ready" else 503
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+# ---------------------------------------------------------------------------
+# 7.1  List Users
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/users",
+    response_model=UserListResponse,
+    summary="List users (admin only)",
+)
+async def list_users_endpoint(
+    role: str | None = Query(default=None),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    principal: AuthenticatedPrincipal = Depends(_require_admin),
+):
+    async with _runtime_engine().connect() as conn:
+        rows = await list_users(conn, role=role)
+
+    page, next_cursor = _build_user_page(rows, cursor=cursor, limit=limit)
+    return UserListResponse(
+        users=[_user_out(r) for r in page],
+        next_cursor=next_cursor,
+    ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# 7.2  Update User Role
+# ---------------------------------------------------------------------------
+
+
+@app.patch(
+    "/users/{user_id}",
+    response_model=UserOut,
+    summary="Update a user's role (admin only)",
+)
+async def update_user_role_endpoint(
+    user_id: uuid.UUID,
+    body: UpdateUserRoleRequest,
+    principal: AuthenticatedPrincipal = Depends(_require_admin),
+):
+    async with _runtime_engine().connect() as conn:
+        row = await update_user_role(conn, user_id=user_id, new_role=body.role)
+
+    if row is None:
+        return _error("user_not_found", "User not found.", status.HTTP_404_NOT_FOUND)
+
+    return _user_out(row)
+
+
+# ---------------------------------------------------------------------------
+# 7.4  Create Course
+# ---------------------------------------------------------------------------
+
+
+@app.post(
+    "/courses",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CourseResponse,
+    summary="Create a new course (admin only)",
+)
+async def create_course_endpoint(
+    body: CreateCourseRequest,
+    principal: AuthenticatedPrincipal = Depends(_require_admin),
+):
+    async with _runtime_engine().connect() as conn:
+        row = await create_course(
+            conn,
+            title=body.title,
+            description=body.description,
+            content_url=str(body.content_url),
+            category=body.category,
+            difficulty=body.difficulty,
+        )
+
+    return CourseResponse(course=_course_out(row)).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# 7.5  Disburse Treasury Funds
+# ---------------------------------------------------------------------------
+
+
+@app.post(
+    "/treasury/disburse",
+    response_model=TreasuryDisburseResponse,
+    summary="Disburse treasury funds (admin only, requires 2FA)",
+)
+async def disburse_treasury_endpoint(
+    body: TreasuryDisburseRequest,
+    x_2fa_code: Annotated[str | None, Header(alias="X-2FA-Code")] = None,
+    principal: AuthenticatedPrincipal = Depends(_require_admin),
+):
+    async with _runtime_engine().connect() as conn:
+        await _check_2fa(conn, principal.id, x_2fa_code)
+        try:
+            row = await disburse_treasury(
+                conn,
+                amount_sat=body.amount_sat,
+                description=body.description,
+            )
+        except ValueError as exc:
+            if "insufficient" in str(exc):
+                return _error(
+                    "insufficient_treasury_balance",
+                    "Treasury balance is insufficient for this disbursement.",
+                    status.HTTP_409_CONFLICT,
+                )
+            raise
+
+    return TreasuryDisburseResponse(
+        entry=_treasury_entry_out(row)
+    ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# 7.3  Resolve Dispute (admin escrow resolve)
+# ---------------------------------------------------------------------------
+
+
+@app.post(
+    "/escrows/{trade_id}/resolve",
+    response_model=DisputeResponse,
+    summary="Resolve an escrow dispute (admin only, requires 2FA)",
+)
+async def resolve_escrow_dispute_endpoint(
+    trade_id: uuid.UUID,
+    body: AdminDisputeResolveRequest,
+    x_2fa_code: Annotated[str | None, Header(alias="X-2FA-Code")] = None,
+    principal: AuthenticatedPrincipal = Depends(_require_admin),
+):
+    # Map API resolution values to internal DB values
+    resolution_map = {
+        "refund_buyer": "refund",
+        "release_to_seller": "release",
+    }
+    db_resolution = resolution_map[body.resolution]
+
+    async with _runtime_engine().connect() as conn:
+        await _check_2fa(conn, principal.id, x_2fa_code)
+
+        existing_dispute = await get_dispute_by_trade_id(conn, trade_id)
+        if existing_dispute is None:
+            return _error(
+                "dispute_not_found",
+                "No dispute found for this trade.",
+                status.HTTP_404_NOT_FOUND,
+            )
+
+        if _row_value(existing_dispute, "status") != "open":
+            return _error(
+                "dispute_already_resolved",
+                "This dispute has already been resolved.",
+                status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            dispute_row, _trade_row, _escrow_row = await resolve_dispute(
+                conn,
+                trade_id=trade_id,
+                resolved_by=principal.id,
+                resolution=db_resolution,
+            )
+        except LookupError as exc:
+            return _error(
+                "resolution_conflict",
+                "Could not apply resolution due to a state conflict.",
+                status.HTTP_409_CONFLICT,
+            )
+
+    return DisputeResponse(dispute=_dispute_out(dispute_row)).model_dump(mode="json")
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=settings.service_host, port=settings.service_port)

--- a/services/admin/requirements.txt
+++ b/services/admin/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic-settings
+sqlalchemy
+asyncpg
+python-jose[cryptography]

--- a/services/admin/schemas.py
+++ b/services/admin/schemas.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# User Management Schemas
+# ---------------------------------------------------------------------------
+
+class UserOut(BaseModel):
+    id: str
+    email: str | None = None
+    display_name: str
+    role: str
+    created_at: datetime
+
+
+class UserListResponse(BaseModel):
+    users: list[UserOut]
+    next_cursor: str | None
+
+
+class UpdateUserRoleRequest(BaseModel):
+    role: Literal["user", "seller", "admin", "auditor"]
+
+
+# ---------------------------------------------------------------------------
+# Course Schemas
+# ---------------------------------------------------------------------------
+
+CourseCategory = Literal["bitcoin", "finance", "programming", "entrepreneurship"]
+CourseDifficulty = Literal["beginner", "intermediate", "advanced"]
+
+
+class CreateCourseRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    description: str = Field(min_length=1)
+    content_url: str = Field(pattern=r"^https?://")
+    category: CourseCategory
+    difficulty: CourseDifficulty
+
+
+class CourseOut(BaseModel):
+    id: str
+    title: str
+    description: str
+    category: CourseCategory
+    difficulty: CourseDifficulty
+    content_url: str
+
+
+class CourseResponse(BaseModel):
+    course: CourseOut
+
+
+# ---------------------------------------------------------------------------
+# Treasury Schemas
+# ---------------------------------------------------------------------------
+
+class TreasuryDisburseRequest(BaseModel):
+    amount_sat: int = Field(gt=0)
+    description: str = Field(min_length=1, max_length=255)
+
+
+class TreasuryEntryOut(BaseModel):
+    id: str
+    type: str
+    amount_sat: int
+    balance_after_sat: int
+    reference_id: str | None = None
+    description: str | None = None
+    created_at: datetime
+
+
+class TreasuryDisburseResponse(BaseModel):
+    entry: TreasuryEntryOut
+
+
+# ---------------------------------------------------------------------------
+# Dispute Schemas
+# ---------------------------------------------------------------------------
+
+class AdminDisputeResolveRequest(BaseModel):
+    resolution: Literal["refund_buyer", "release_to_seller"]
+    notes: str = Field(min_length=1)
+
+
+class DisputeOut(BaseModel):
+    id: str
+    trade_id: str
+    opened_by: str
+    reason: str
+    status: str
+    resolution: str | None = None
+    resolved_by: str | None = None
+    notes: str | None = None
+    resolved_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DisputeResponse(BaseModel):
+    dispute: DisputeOut

--- a/services/gateway/default.conf
+++ b/services/gateway/default.conf
@@ -42,6 +42,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # Admin Service
+    location /v1/admin/ {
+        rewrite ^/v1/admin/(.*) /$1 break;
+        proxy_pass http://admin:8006;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Health check for the Gateway itself
     location /health {
         return 200 '{"status":"ok","service":"gateway"}';

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+import os
+import sys
+from typing import NamedTuple
+from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.auth.jwt_utils import issue_token_pair
+
+
+# ---------------------------------------------------------------------------
+# Fake DB rows
+# ---------------------------------------------------------------------------
+
+
+class FakeUser(NamedTuple):
+    id: uuid.UUID
+    email: str
+    display_name: str
+    role: str
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None
+    totp_secret: str | None = None
+
+
+class FakeCourse(NamedTuple):
+    id: uuid.UUID
+    title: str
+    description: str
+    content_url: str
+    category: str
+    difficulty: str
+    is_published: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class FakeTreasuryEntry(NamedTuple):
+    id: uuid.UUID
+    type: str
+    amount_sat: int
+    balance_after_sat: int
+    source_trade_id: uuid.UUID | None
+    description: str | None
+    created_at: datetime
+
+
+class FakeDispute(NamedTuple):
+    id: uuid.UUID
+    trade_id: uuid.UUID
+    opened_by: uuid.UUID
+    reason: str
+    status: str
+    resolution: str | None
+    resolved_by: uuid.UUID | None
+    resolved_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def _make_user(*, role: str = "user", totp_secret: str | None = None) -> FakeUser:
+    now = datetime.now(tz=timezone.utc)
+    return FakeUser(
+        id=uuid.uuid4(),
+        email="user@example.com",
+        display_name="Test User",
+        role=role,
+        created_at=now,
+        updated_at=now,
+        deleted_at=None,
+        totp_secret=totp_secret,
+    )
+
+
+def _make_course() -> FakeCourse:
+    now = datetime.now(tz=timezone.utc)
+    return FakeCourse(
+        id=uuid.uuid4(),
+        title="Bitcoin 101",
+        description="Introduction to Bitcoin.",
+        content_url="https://example.com/bitcoin-101",
+        category="bitcoin",
+        difficulty="beginner",
+        is_published=False,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_treasury_entry(*, entry_type: str = "fee_income", amount: int = 5000, balance: int = 15000) -> FakeTreasuryEntry:
+    return FakeTreasuryEntry(
+        id=uuid.uuid4(),
+        type=entry_type,
+        amount_sat=amount,
+        balance_after_sat=balance,
+        source_trade_id=None,
+        description=None,
+        created_at=datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_dispute(*, status: str = "open") -> FakeDispute:
+    now = datetime.now(tz=timezone.utc)
+    return FakeDispute(
+        id=uuid.uuid4(),
+        trade_id=uuid.uuid4(),
+        opened_by=uuid.uuid4(),
+        reason="Seller did not deliver.",
+        status=status,
+        resolution=None,
+        resolved_by=None,
+        resolved_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env settings fixture
+# ---------------------------------------------------------------------------
+
+
+_ADMIN_SETTINGS = {
+    "ENV_PROFILE": "local",
+    "WALLET_SERVICE_URL": "http://wallet:8001",
+    "TOKENIZATION_SERVICE_URL": "http://tokenization:8002",
+    "MARKETPLACE_SERVICE_URL": "http://marketplace:8003",
+    "EDUCATION_SERVICE_URL": "http://education:8004",
+    "NOSTR_SERVICE_URL": "http://nostr:8005",
+    "ADMIN_SERVICE_URL": "http://admin:8006",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "testdb",
+    "POSTGRES_USER": "user",
+    "DATABASE_URL": "postgresql://user:pass@localhost/testdb",
+    "REDIS_URL": "redis://localhost:6379/0",
+    "BITCOIN_RPC_HOST": "localhost",
+    "BITCOIN_RPC_PORT": "18443",
+    "BITCOIN_RPC_USER": "bitcoin",
+    "BITCOIN_NETWORK": "regtest",
+    "LND_GRPC_HOST": "localhost",
+    "LND_GRPC_PORT": "10009",
+    "LND_MACAROON_PATH": "tests/fixtures/admin.macaroon",
+    "LND_TLS_CERT_PATH": "tests/fixtures/tls.cert",
+    "TAPD_GRPC_HOST": "localhost",
+    "TAPD_GRPC_PORT": "10029",
+    "TAPD_MACAROON_PATH": "tests/fixtures/tapd.macaroon",
+    "TAPD_TLS_CERT_PATH": "tests/fixtures/tapd.cert",
+    "NOSTR_RELAYS": "wss://relay.example.com",
+    "JWT_SECRET": "test-secret-key-for-admin-tests",
+    "JWT_ACCESS_TOKEN_EXPIRE_MINUTES": "15",
+    "JWT_REFRESH_TOKEN_EXPIRE_DAYS": "7",
+    "TOTP_ISSUER": "Platform",
+    "LOG_LEVEL": "INFO",
+}
+
+
+@pytest.fixture()
+def client():
+    fake_conn = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield fake_conn
+
+    fake_engine = MagicMock()
+    fake_engine.connect = _fake_connect
+    fake_engine.dispose = AsyncMock()
+
+    with patch.dict(os.environ, _ADMIN_SETTINGS, clear=False):
+        for module_name in (
+            "services.admin.main",
+            "services.admin.db",
+            "services.admin.schemas",
+            "common",
+            "common.config",
+        ):
+            sys.modules.pop(module_name, None)
+
+        import services.admin.main as admin_main
+
+        admin_main._engine = fake_engine
+        app = admin_main.app
+        app.router.lifespan_context = None
+
+        yield TestClient(app, raise_server_exceptions=True), admin_main.settings
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue_token(user: FakeUser, secret: str) -> str:
+    return issue_token_pair(
+        user_id=str(user.id),
+        role=user.role,
+        wallet_id=None,
+        secret=secret,
+    ).access_token
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# GET /users
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_list_users(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    user1 = _make_user(role="user")
+    user2 = _make_user(role="seller")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.list_users", AsyncMock(return_value=[user1, user2])),
+    ):
+        response = app_client.get("/users", headers=_auth(token))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["users"]) == 2
+    assert data["next_cursor"] is None
+
+
+def test_admin_can_list_users_filtered_by_role(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    seller = _make_user(role="seller")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.list_users", AsyncMock(return_value=[seller])) as mock_list,
+    ):
+        response = app_client.get("/users?role=seller", headers=_auth(token))
+
+    assert response.status_code == 200
+    assert len(response.json()["users"]) == 1
+
+
+def test_non_admin_cannot_list_users(client):
+    app_client, settings = client
+    regular = _make_user(role="user")
+    token = _issue_token(regular, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=regular)):
+        response = app_client.get("/users", headers=_auth(token))
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /users/{user_id}
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_update_user_role(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    target = _make_user(role="user")
+    updated = target._replace(role="seller")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.update_user_role", AsyncMock(return_value=updated)),
+    ):
+        response = app_client.patch(
+            f"/users/{target.id}",
+            json={"role": "seller"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "seller"
+
+
+def test_admin_cannot_update_role_to_invalid_value(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)):
+        response = app_client.patch(
+            f"/users/{uuid.uuid4()}",
+            json={"role": "superuser"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 422
+
+
+def test_non_admin_cannot_update_role(client):
+    app_client, settings = client
+    regular = _make_user(role="user")
+    token = _issue_token(regular, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=regular)):
+        response = app_client.patch(
+            f"/users/{uuid.uuid4()}",
+            json={"role": "seller"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /courses
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_create_course(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    course = _make_course()
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.create_course", AsyncMock(return_value=course)),
+    ):
+        response = app_client.post(
+            "/courses",
+            json={
+                "title": course.title,
+                "description": course.description,
+                "content_url": course.content_url,
+                "category": course.category,
+                "difficulty": course.difficulty,
+            },
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["course"]["title"] == course.title
+    assert data["course"]["category"] == "bitcoin"
+
+
+def test_non_admin_cannot_create_course(client):
+    app_client, settings = client
+    regular = _make_user(role="user")
+    token = _issue_token(regular, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=regular)):
+        response = app_client.post(
+            "/courses",
+            json={
+                "title": "Test",
+                "description": "Desc",
+                "content_url": "https://example.com",
+                "category": "bitcoin",
+                "difficulty": "beginner",
+            },
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /treasury/disburse
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_disburse_treasury_funds(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    entry = _make_treasury_entry(entry_type="disbursement", amount=500000, balance=14500000)
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.disburse_treasury", AsyncMock(return_value=entry)),
+    ):
+        response = app_client.post(
+            "/treasury/disburse",
+            json={"amount_sat": 500000, "description": "Q2 educational program"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["entry"]["type"] == "disbursement"
+    assert data["entry"]["amount_sat"] == 500000
+
+
+def test_treasury_disburse_requires_2fa_when_enabled(client):
+    """When user has totp_secret set, X-2FA-Code header must be provided."""
+    app_client, settings = client
+    admin = _make_user(role="admin", totp_secret="JBSWY3DPEHPK3PXP")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)):
+        response = app_client.post(
+            "/treasury/disburse",
+            json={"amount_sat": 500000, "description": "test"},
+            headers=_auth(token),
+            # No X-2FA-Code header
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "2fa_required"
+
+
+def test_non_admin_cannot_disburse_treasury(client):
+    app_client, settings = client
+    regular = _make_user(role="user")
+    token = _issue_token(regular, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=regular)):
+        response = app_client.post(
+            "/treasury/disburse",
+            json={"amount_sat": 100, "description": "test"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /escrows/{trade_id}/resolve
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_resolve_dispute(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    dispute = _make_dispute(status="open")
+    resolved_dispute = dispute._replace(status="resolved", resolution="refund")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    fake_trade = MagicMock()
+    fake_escrow = MagicMock()
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.get_dispute_by_trade_id", AsyncMock(return_value=dispute)),
+        patch(
+            "services.admin.main.resolve_dispute",
+            AsyncMock(return_value=(resolved_dispute, fake_trade, fake_escrow)),
+        ),
+    ):
+        response = app_client.post(
+            f"/escrows/{dispute.trade_id}/resolve",
+            json={"resolution": "refund_buyer", "notes": "Seller failed to deliver."},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dispute"]["status"] == "resolved"
+    assert data["dispute"]["resolution"] == "refund"
+
+
+def test_resolve_dispute_not_found(client):
+    app_client, settings = client
+    admin = _make_user(role="admin")
+    token = _issue_token(admin, settings.jwt_secret)
+
+    with (
+        patch("services.admin.main.get_user_by_id", AsyncMock(return_value=admin)),
+        patch("services.admin.main.get_dispute_by_trade_id", AsyncMock(return_value=None)),
+    ):
+        response = app_client.post(
+            f"/escrows/{uuid.uuid4()}/resolve",
+            json={"resolution": "refund_buyer", "notes": "test"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 404
+
+
+def test_non_admin_cannot_resolve_dispute(client):
+    app_client, settings = client
+    regular = _make_user(role="user")
+    token = _issue_token(regular, settings.jwt_secret)
+
+    with patch("services.admin.main.get_user_by_id", AsyncMock(return_value=regular)):
+        response = app_client.post(
+            f"/escrows/{uuid.uuid4()}/resolve",
+            json={"resolution": "refund_buyer", "notes": "test"},
+            headers=_auth(token),
+        )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary

Closes #44 

Implements the admin API surface per `specs/api-contracts.md §7`.

## Changes

### New service: `services/admin/`

A new standalone FastAPI microservice (port 8006) with 5 admin-only endpoints:

| Method | Path | 2FA Required | Description |
|--------|------|-------------|-------------|
| `GET` | `/users` | — | List users with optional `?role=` filter and cursor pagination |
| `PATCH` | `/users/{user_id}` | — | Update a user's role |
| `POST` | `/courses` | — | Create a new course |
| `POST` | `/treasury/disburse` | ✅ | Disburse treasury funds |
| `POST` | `/escrows/{trade_id}/resolve` | ✅ | Resolve an open escrow dispute |

All endpoints require `role == "admin"` enforced via JWT RBAC.

### Gateway

- `services/gateway/default.conf`: Added `/v1/admin/` proxy block routing to `admin:8006`.

### Tests

- `tests/test_admin.py`: 14 tests covering all endpoints, RBAC enforcement, 2FA requirement, and error paths.

## Acceptance Criteria

- [x] Admins can list users and update roles.
- [x] Admins can create courses and disburse treasury funds.
- [x] Admin-only protections are enforced on all management endpoints.

## Test Results

```
14 passed in 1.66s
```
