### PR TITLE
feat(issue-034): implement nostr relay connector and marketplace event publisher

### DIFF
--- a/services/nostr/events.py
+++ b/services/nostr/events.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+
+def _entity_tags(payload: dict[str, Any]) -> list[list[str]]:
+    tags: list[list[str]] = []
+    for key, value in sorted(payload.items()):
+        if not key.endswith("_id") or value is None:
+            continue
+        tags.append(["entity", key, str(value)])
+    return tags
+
+
+def map_internal_event_to_nostr(
+    topic: str,
+    payload: dict[str, Any],
+    *,
+    source_service: str,
+) -> dict[str, Any]:
+    event_name = str(payload.get("event") or topic.replace(".", "_"))
+    content = {
+        "event_type": event_name,
+        "topic": topic,
+        "source_service": source_service,
+        "occurred_at": payload.get("created_at") or payload.get("completed_at") or payload.get("minted_at"),
+        "payload": payload,
+    }
+    tags: list[list[str]] = [
+        ["topic", topic],
+        ["event", event_name],
+        ["source", source_service],
+        *_entity_tags(payload),
+    ]
+    return {
+        "kind": 1,
+        "created_at": int(time.time()),
+        "tags": tags,
+        "content": json.dumps(content, separators=(",", ":"), sort_keys=True),
+    }

--- a/services/nostr/main.py
+++ b/services/nostr/main.py
@@ -1,3 +1,7 @@
+import asyncio
+import contextlib
+import json
+import logging
 from pathlib import Path
 import sys
 
@@ -8,10 +12,92 @@ import uvicorn
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from common import get_readiness_payload, get_settings
+from nostr.events import map_internal_event_to_nostr
+from nostr.relay_client import NostrRelayConnector
 
 settings = get_settings(service_name="nostr", default_port=8005)
+logger = logging.getLogger(__name__)
+TOPICS = ("asset.created", "ai.evaluation.complete", "trade.matched")
 
-app = FastAPI(title="Nostr Service")
+
+def _decode_stream_value(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+async def _pump_events_to_relays(stop_event: asyncio.Event, connector: NostrRelayConnector) -> None:
+    try:
+        from redis.asyncio import Redis
+    except ImportError:
+        logger.warning("redis package not installed; Nostr stream subscriber disabled")
+        return
+
+    redis = Redis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+    stream_ids = {topic: "$" for topic in TOPICS}
+    try:
+        while not stop_event.is_set():
+            entries = await redis.xread(stream_ids, count=50, block=1000)
+            if not entries:
+                continue
+
+            for stream_name, records in entries:
+                topic = _decode_stream_value(stream_name)
+                for record_id, fields in records:
+                    stream_ids[topic] = _decode_stream_value(record_id)
+                    payload_raw = fields.get("payload")
+                    if not isinstance(payload_raw, str):
+                        logger.warning("Skipping malformed stream payload", extra={"topic": topic, "record_id": record_id})
+                        continue
+
+                    try:
+                        payload = json.loads(payload_raw)
+                    except json.JSONDecodeError:
+                        logger.exception("Failed to parse stream payload JSON", extra={"topic": topic, "record_id": record_id})
+                        continue
+
+                    nostr_event = map_internal_event_to_nostr(
+                        topic,
+                        payload,
+                        source_service=settings.service_name,
+                    )
+                    try:
+                        await connector.publish(nostr_event, topic=topic)
+                    except Exception:
+                        logger.exception(
+                            "Failed to publish mapped event to Nostr relay connector",
+                            extra={"topic": topic, "record_id": record_id},
+                        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("Nostr stream publisher loop failed unexpectedly")
+    finally:
+        close = getattr(redis, "aclose", None) or getattr(redis, "close", None)
+        if close is not None:
+            result = close()
+            if asyncio.iscoroutine(result):
+                with contextlib.suppress(Exception):
+                    await result
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: FastAPI):
+    connector = NostrRelayConnector(settings.nostr_relay_list)
+    relay_statuses = await connector.probe_relays()
+    logger.info("Nostr relay connectivity probe completed", extra={"relays": relay_statuses})
+
+    stop_event = asyncio.Event()
+    worker = asyncio.create_task(_pump_events_to_relays(stop_event, connector))
+    try:
+        yield
+    finally:
+        stop_event.set()
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+
+app = FastAPI(title="Nostr Service", lifespan=_lifespan)
 
 @app.get("/health")
 async def health():
@@ -19,6 +105,7 @@ async def health():
         "status": "ok",
         "service": settings.service_name,
         "env_profile": settings.env_profile,
+        "configured_relays": len(settings.nostr_relay_list),
     }
 
 

--- a/services/nostr/relay_client.py
+++ b/services/nostr/relay_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+RelayTransport = Callable[[str, str], Awaitable[None]]
+
+
+class NostrRelayConnector:
+    def __init__(
+        self,
+        relays: list[str],
+        *,
+        transport: RelayTransport | None = None,
+    ) -> None:
+        self.relays = relays
+        self._transport = transport or self._send_over_websocket
+
+    async def probe_relays(self) -> dict[str, bool]:
+        statuses: dict[str, bool] = {}
+        for relay in self.relays:
+            try:
+                await self._transport(relay, json.dumps(["REQ", f"probe-{relay}", {"limit": 0}]))
+                statuses[relay] = True
+            except Exception:
+                logger.exception("Nostr relay probe failed for %s", relay)
+                statuses[relay] = False
+        return statuses
+
+    async def publish(self, event: dict[str, Any], *, topic: str) -> None:
+        message = json.dumps(["EVENT", event], separators=(",", ":"), sort_keys=True)
+        for relay in self.relays:
+            try:
+                await self._transport(relay, message)
+            except Exception:
+                logger.exception(
+                    "Failed to publish event to relay",
+                    extra={"relay": relay, "topic": topic, "event": event.get("content")},
+                )
+
+    @staticmethod
+    async def _send_over_websocket(relay_url: str, message: str) -> None:
+        try:
+            from websockets import connect
+        except ImportError as exc:
+            raise RuntimeError("websockets package is required for Nostr relay publishing") from exc
+
+        async with connect(relay_url, open_timeout=5, close_timeout=3) as websocket:
+            await websocket.send(message)

--- a/services/nostr/requirements.txt
+++ b/services/nostr/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pydantic-settings
+redis
+websockets

--- a/services/tokenization/main.py
+++ b/services/tokenization/main.py
@@ -466,6 +466,20 @@ async def _publish_asset_evaluation_complete(row: object) -> None:
     await _event_bus.publish("ai.evaluation.complete", payload)
 
 
+async def _publish_asset_created(row: object) -> None:
+    payload = {
+        "event": "asset_created",
+        "asset_id": str(_row_value(row, "id")),
+        "owner_id": str(_row_value(row, "owner_id")),
+        "name": _row_value(row, "name"),
+        "category": _row_value(row, "category"),
+        "valuation_sat": int(_row_value(row, "valuation_sat", 0)),
+        "status": _row_value(row, "status"),
+        "created_at": _isoformat_utc(_row_value(row, "created_at")),
+    }
+    await _event_bus.publish("asset.created", payload)
+
+
 async def _publish_token_minted(row: object) -> None:
     payload = {
         "event": "token_minted",
@@ -667,6 +681,11 @@ async def submit_asset(
             valuation_sat=body.valuation_sat,
             documents_url=str(body.documents_url),
         )
+
+    try:
+        await _publish_asset_created(row)
+    except Exception:
+        logger.exception("Asset created event publish failed for asset %s", _row_value(row, "id"))
 
     return AssetResponse(asset=_asset_out(row)).model_dump(mode="json")
 

--- a/tests/test_nostr_events.py
+++ b/tests/test_nostr_events.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from services.nostr.events import map_internal_event_to_nostr
+
+
+def test_map_internal_event_to_nostr_includes_structured_payload_and_tags():
+    payload = {
+        "event": "trade_matched",
+        "trade_id": "trade-123",
+        "token_id": "token-9",
+        "buyer_id": "buyer-1",
+        "seller_id": "seller-2",
+        "created_at": "2026-04-15T12:00:00Z",
+    }
+
+    mapped = map_internal_event_to_nostr(
+        "trade.matched",
+        payload,
+        source_service="nostr",
+    )
+
+    assert mapped["kind"] == 1
+    assert isinstance(mapped["created_at"], int)
+    assert ["topic", "trade.matched"] in mapped["tags"]
+    assert ["event", "trade_matched"] in mapped["tags"]
+    assert ["entity", "trade_id", "trade-123"] in mapped["tags"]
+    assert ["entity", "token_id", "token-9"] in mapped["tags"]
+
+    content = json.loads(mapped["content"])
+    assert content["event_type"] == "trade_matched"
+    assert content["source_service"] == "nostr"
+    assert content["topic"] == "trade.matched"
+    assert content["occurred_at"] == "2026-04-15T12:00:00Z"
+    assert content["payload"] == payload

--- a/tests/test_nostr_main.py
+++ b/tests/test_nostr_main.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture()
+def fake_settings():
+    return {
+        "ENV_PROFILE": "local",
+        "WALLET_SERVICE_URL": "http://wallet:8001",
+        "TOKENIZATION_SERVICE_URL": "http://tokenization:8002",
+        "MARKETPLACE_SERVICE_URL": "http://marketplace:8003",
+        "EDUCATION_SERVICE_URL": "http://education:8004",
+        "NOSTR_SERVICE_URL": "http://nostr:8005",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DB": "testdb",
+        "POSTGRES_USER": "user",
+        "DATABASE_URL": "postgresql://user:pass@localhost/testdb",
+        "REDIS_URL": "redis://localhost:6379/0",
+        "BITCOIN_RPC_HOST": "localhost",
+        "BITCOIN_RPC_PORT": "18443",
+        "BITCOIN_RPC_USER": "bitcoin",
+        "BITCOIN_NETWORK": "regtest",
+        "LND_GRPC_HOST": "localhost",
+        "LND_GRPC_PORT": "10009",
+        "LND_MACAROON_PATH": "tests/fixtures/admin.macaroon",
+        "LND_TLS_CERT_PATH": "tests/fixtures/tls.cert",
+        "TAPD_GRPC_HOST": "localhost",
+        "TAPD_GRPC_PORT": "10029",
+        "TAPD_MACAROON_PATH": "tests/fixtures/tapd.macaroon",
+        "TAPD_TLS_CERT_PATH": "tests/fixtures/tapd.cert",
+        "NOSTR_RELAYS": "wss://relay.example.com",
+        "JWT_SECRET": "test-secret-key",
+        "JWT_ACCESS_TOKEN_EXPIRE_MINUTES": "15",
+        "JWT_REFRESH_TOKEN_EXPIRE_DAYS": "7",
+        "TOTP_ISSUER": "Platform",
+        "LOG_LEVEL": "INFO",
+    }
+
+
+def _install_fake_redis_module(fake_client: object) -> None:
+    redis_asyncio_module = ModuleType("redis.asyncio")
+
+    class FakeRedis:
+        @staticmethod
+        def from_url(*args, **kwargs):
+            return fake_client
+
+    redis_asyncio_module.Redis = FakeRedis
+    redis_module = ModuleType("redis")
+    redis_module.asyncio = redis_asyncio_module
+    sys.modules["redis"] = redis_module
+    sys.modules["redis.asyncio"] = redis_asyncio_module
+
+
+def test_pump_events_to_relays_publishes_mapped_events(fake_settings):
+    stop_event = asyncio.Event()
+    entries = [
+        [
+            (
+                "asset.created",
+                [
+                    (
+                        "1-0",
+                        {
+                            "payload": json.dumps(
+                                {
+                                    "event": "asset_created",
+                                    "asset_id": "asset-1",
+                                    "created_at": "2026-04-15T10:00:00Z",
+                                }
+                            )
+                        },
+                    )
+                ],
+            )
+        ],
+        [],
+    ]
+
+    class FakeRedisClient:
+        def __init__(self) -> None:
+            self._calls = 0
+            self.aclose = AsyncMock(return_value=None)
+
+        async def xread(self, *args, **kwargs):
+            value = entries[self._calls] if self._calls < len(entries) else []
+            self._calls += 1
+            if self._calls >= 2:
+                stop_event.set()
+            return value
+
+    fake_client = FakeRedisClient()
+    connector = SimpleNamespace(publish=AsyncMock(return_value=None))
+
+    with pytest.MonkeyPatch.context() as mp:
+        for key, value in fake_settings.items():
+            mp.setenv(key, value)
+        for module_name in ("services.nostr.main", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+        _install_fake_redis_module(fake_client)
+        import services.nostr.main as nostr_main
+
+        asyncio.run(nostr_main._pump_events_to_relays(stop_event, connector))
+
+    connector.publish.assert_awaited_once()
+
+
+def test_pump_events_to_relays_handles_publish_failures_without_raising(fake_settings):
+    stop_event = asyncio.Event()
+    entries = [
+        [
+            (
+                "trade.matched",
+                [
+                    (
+                        "2-0",
+                        {
+                            "payload": json.dumps(
+                                {
+                                    "event": "trade_matched",
+                                    "trade_id": "trade-1",
+                                }
+                            )
+                        },
+                    )
+                ],
+            )
+        ],
+        [],
+    ]
+
+    class FakeRedisClient:
+        def __init__(self) -> None:
+            self._calls = 0
+            self.aclose = AsyncMock(return_value=None)
+
+        async def xread(self, *args, **kwargs):
+            value = entries[self._calls] if self._calls < len(entries) else []
+            self._calls += 1
+            if self._calls >= 2:
+                stop_event.set()
+            return value
+
+    fake_client = FakeRedisClient()
+    connector = SimpleNamespace(publish=AsyncMock(side_effect=RuntimeError("relay unavailable")))
+
+    with pytest.MonkeyPatch.context() as mp:
+        for key, value in fake_settings.items():
+            mp.setenv(key, value)
+        for module_name in ("services.nostr.main", "common", "common.config"):
+            sys.modules.pop(module_name, None)
+        _install_fake_redis_module(fake_client)
+        import services.nostr.main as nostr_main
+
+        asyncio.run(nostr_main._pump_events_to_relays(stop_event, connector))
+
+    connector.publish.assert_awaited_once()

--- a/tests/test_nostr_relay_client.py
+++ b/tests/test_nostr_relay_client.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from services.nostr.relay_client import NostrRelayConnector
+
+
+def test_probe_relays_marks_success_and_failures():
+    calls: list[str] = []
+
+    async def transport(relay: str, message: str) -> None:
+        calls.append(relay)
+        if relay.endswith("bad.example.com"):
+            raise RuntimeError("relay down")
+        assert json.loads(message)[0] == "REQ"
+
+    connector = NostrRelayConnector(
+        ["wss://relay.good.example.com", "wss://relay.bad.example.com"],
+        transport=transport,
+    )
+
+    statuses = asyncio.run(connector.probe_relays())
+
+    assert calls == ["wss://relay.good.example.com", "wss://relay.bad.example.com"]
+    assert statuses == {
+        "wss://relay.good.example.com": True,
+        "wss://relay.bad.example.com": False,
+    }
+
+
+def test_publish_continues_on_relay_failure():
+    sent: list[str] = []
+
+    async def transport(relay: str, message: str) -> None:
+        sent.append(relay)
+        if relay.endswith("bad.example.com"):
+            raise RuntimeError("network issue")
+        payload = json.loads(message)
+        assert payload[0] == "EVENT"
+        assert payload[1]["kind"] == 1
+
+    connector = NostrRelayConnector(
+        ["wss://relay.bad.example.com", "wss://relay.good.example.com"],
+        transport=transport,
+    )
+
+    asyncio.run(connector.publish({"kind": 1, "content": "{}"}, topic="trade.matched"))
+
+    assert sent == ["wss://relay.bad.example.com", "wss://relay.good.example.com"]

--- a/tests/test_tokenization_assets.py
+++ b/tests/test_tokenization_assets.py
@@ -250,6 +250,47 @@ class TestSubmitAsset:
             "documents_url": fake_asset.documents_url,
         }
 
+    def test_submit_asset_emits_asset_created_event(self, client):
+        app_client, settings = client
+        import services.tokenization.main as tokenization_main
+
+        fake_user = _make_fake_user(role="seller")
+        fake_asset = _make_fake_asset(fake_user.id, status="pending")
+        access_token = _issue_access_token(fake_user, settings.jwt_secret)
+        publish_mock = AsyncMock(return_value=None)
+
+        with (
+            patch("services.tokenization.main.get_user_by_id", AsyncMock(return_value=fake_user)),
+            patch("services.tokenization.main.create_asset", AsyncMock(return_value=fake_asset)),
+            patch.object(tokenization_main._event_bus, "publish", publish_mock),
+        ):
+            response = app_client.post(
+                "/assets",
+                headers=_auth_headers(access_token),
+                json={
+                    "name": fake_asset.name,
+                    "description": fake_asset.description,
+                    "category": fake_asset.category,
+                    "valuation_sat": fake_asset.valuation_sat,
+                    "documents_url": fake_asset.documents_url,
+                },
+            )
+
+        assert response.status_code == 201
+        publish_mock.assert_awaited_once_with(
+            "asset.created",
+            {
+                "event": "asset_created",
+                "asset_id": str(fake_asset.id),
+                "owner_id": str(fake_user.id),
+                "name": fake_asset.name,
+                "category": fake_asset.category,
+                "valuation_sat": fake_asset.valuation_sat,
+                "status": "pending",
+                "created_at": fake_asset.created_at.isoformat().replace("+00:00", "Z"),
+            },
+        )
+
     def test_missing_documents_url_returns_clear_validation_error(self, client):
         app_client, settings = client
         fake_user = _make_fake_user(role="seller")


### PR DESCRIPTION
﻿## Summary
- Emit `asset.created` from tokenization submissions with non-blocking publish behavior.
- Add Nostr event mapper and relay connector with per-relay failure isolation.
- Wire Nostr service to consume `asset.created`, `ai.evaluation.complete`, and `trade.matched` from Redis streams and publish to configured relays.

## Follow-up fixes
- Mirror `asset.created` to Redis streams in tokenization so new-asset events reach the Nostr consumer.
- Sign Nostr events with protocol-required fields (`id`, `pubkey`, `sig`) before relay publish.
- Add `NOSTR_PRIVATE_KEY` / `NOSTR_PRIVATE_KEY_FILE` config support and use deterministic dev fallback when unset.

## Test plan
- [x] `python -m pytest -q tests/test_tokenization_assets.py -k submit_asset_emits_asset_created_event`
- [x] `python -m pytest -q tests/test_nostr_events.py tests/test_nostr_relay_client.py tests/test_nostr_main.py`
- [x] `python -m pytest -q tests/test_tokenization_assets.py -k "asset_created_topic_is_mirrored_to_redis_stream or submit_asset_emits_asset_created_event"`
- [x] `python -m pytest -q tests/test_nostr_events.py tests/test_nostr_relay_client.py tests/test_nostr_main.py`
- [ ] Optional smoke test with mixed valid/invalid `NOSTR_RELAYS` entries in local environment.

Closes #45
