### PR TITLE
fix(issue-034): mirror asset events and sign nostr payloads

### DIFF
--- a/services/common/config.py
+++ b/services/common/config.py
@@ -55,6 +55,8 @@ class Settings(BaseSettings):
     tapd_tls_cert_path: str
 
     nostr_relays: str
+    nostr_private_key: str | None = None
+    nostr_private_key_file: str | None = None
 
     jwt_secret: str | None = None
     jwt_secret_file: str | None = None
@@ -100,6 +102,7 @@ class Settings(BaseSettings):
         self.jwt_secret = self._resolve_secret(self.jwt_secret, self.jwt_secret_file)
         self.openai_api_key = self._resolve_secret(self.openai_api_key, self.openai_api_key_file)
         self.wallet_encryption_key = self._resolve_secret(self.wallet_encryption_key, self.wallet_encryption_key_file)
+        self.nostr_private_key = self._resolve_secret(self.nostr_private_key, self.nostr_private_key_file)
 
         if self.env_profile in {"staging", "production"}:
             if not self.jwt_secret:

--- a/services/nostr/events.py
+++ b/services/nostr/events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any
+import hashlib
 
 
 def _entity_tags(payload: dict[str, Any]) -> list[list[str]]:
@@ -40,3 +41,63 @@ def map_internal_event_to_nostr(
         "tags": tags,
         "content": json.dumps(content, separators=(",", ":"), sort_keys=True),
     }
+
+
+def _derive_xonly_pubkey(private_key_hex: str) -> str:
+    from btclib.ecc import ssa
+
+    _, x_only_pubkey = ssa.gen_keys(int(private_key_hex, 16))
+    return f"{x_only_pubkey:064x}"
+
+
+def _event_commitment(
+    *,
+    pubkey: str,
+    created_at: int,
+    kind: int,
+    tags: list[list[str]],
+    content: str,
+) -> bytes:
+    raw = json.dumps([0, pubkey, created_at, kind, tags, content], separators=(",", ":"), ensure_ascii=False)
+    return raw.encode("utf-8")
+
+
+def sign_nostr_event(unsigned_event: dict[str, Any], *, private_key_hex: str) -> dict[str, Any]:
+    from btclib.ecc import ssa
+
+    pubkey = _derive_xonly_pubkey(private_key_hex)
+    created_at = int(unsigned_event["created_at"])
+    kind = int(unsigned_event["kind"])
+    tags = unsigned_event["tags"]
+    content = str(unsigned_event["content"])
+
+    commitment = _event_commitment(
+        pubkey=pubkey,
+        created_at=created_at,
+        kind=kind,
+        tags=tags,
+        content=content,
+    )
+    event_id = hashlib.sha256(commitment).hexdigest()
+    signature = ssa.sign_(bytes.fromhex(event_id), int(private_key_hex, 16)).serialize().hex()
+
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "created_at": created_at,
+        "kind": kind,
+        "tags": tags,
+        "content": content,
+        "sig": signature,
+    }
+
+
+def map_and_sign_internal_event(
+    topic: str,
+    payload: dict[str, Any],
+    *,
+    source_service: str,
+    private_key_hex: str,
+) -> dict[str, Any]:
+    unsigned = map_internal_event_to_nostr(topic, payload, source_service=source_service)
+    return sign_nostr_event(unsigned, private_key_hex=private_key_hex)

--- a/services/nostr/main.py
+++ b/services/nostr/main.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import logging
 from pathlib import Path
+import hashlib
 import sys
 
 from fastapi import FastAPI
@@ -12,7 +13,7 @@ import uvicorn
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from common import get_readiness_payload, get_settings
-from nostr.events import map_internal_event_to_nostr
+from nostr.events import map_and_sign_internal_event
 from nostr.relay_client import NostrRelayConnector
 
 settings = get_settings(service_name="nostr", default_port=8005)
@@ -56,10 +57,11 @@ async def _pump_events_to_relays(stop_event: asyncio.Event, connector: NostrRela
                         logger.exception("Failed to parse stream payload JSON", extra={"topic": topic, "record_id": record_id})
                         continue
 
-                    nostr_event = map_internal_event_to_nostr(
+                    nostr_event = map_and_sign_internal_event(
                         topic,
                         payload,
                         source_service=settings.service_name,
+                        private_key_hex=_nostr_private_key(),
                     )
                     try:
                         await connector.publish(nostr_event, topic=topic)
@@ -96,6 +98,15 @@ async def _lifespan(app: FastAPI):
         worker.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await worker
+
+
+def _nostr_private_key() -> str:
+    key = (settings.nostr_private_key or "").strip().lower()
+    if key:
+        return key
+    # Deterministic local fallback to keep publishing operational in dev/test.
+    seed = f"{settings.service_name}:{settings.jwt_secret or 'dev-secret-change-me'}".encode("utf-8")
+    return hashlib.sha256(seed).hexdigest()
 
 app = FastAPI(title="Nostr Service", lifespan=_lifespan)
 

--- a/services/nostr/requirements.txt
+++ b/services/nostr/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic-settings
 redis
 websockets
+btclib

--- a/services/tokenization/main.py
+++ b/services/tokenization/main.py
@@ -57,6 +57,7 @@ _engine: AsyncEngine | object | None = None
 logger = logging.getLogger(__name__)
 _background_tasks: set[asyncio.Task[Any]] = set()
 _event_bus = InternalEventBus()
+_event_bus.subscribe("asset.created", RedisStreamMirror(settings.redis_url))
 _event_bus.subscribe("ai.evaluation.complete", RedisStreamMirror(settings.redis_url))
 
 

--- a/tests/test_nostr_events.py
+++ b/tests/test_nostr_events.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 
-from services.nostr.events import map_internal_event_to_nostr
+from services.nostr.events import map_and_sign_internal_event
 
 
-def test_map_internal_event_to_nostr_includes_structured_payload_and_tags():
+def test_map_and_sign_internal_event_includes_structured_payload_tags_and_signature():
     payload = {
         "event": "trade_matched",
         "trade_id": "trade-123",
@@ -15,14 +15,18 @@ def test_map_internal_event_to_nostr_includes_structured_payload_and_tags():
         "created_at": "2026-04-15T12:00:00Z",
     }
 
-    mapped = map_internal_event_to_nostr(
+    mapped = map_and_sign_internal_event(
         "trade.matched",
         payload,
         source_service="nostr",
+        private_key_hex="1" * 64,
     )
 
     assert mapped["kind"] == 1
     assert isinstance(mapped["created_at"], int)
+    assert len(mapped["id"]) == 64
+    assert len(mapped["pubkey"]) == 64
+    assert len(mapped["sig"]) == 128
     assert ["topic", "trade.matched"] in mapped["tags"]
     assert ["event", "trade_matched"] in mapped["tags"]
     assert ["entity", "trade_id", "trade-123"] in mapped["tags"]

--- a/tests/test_tokenization_assets.py
+++ b/tests/test_tokenization_assets.py
@@ -206,6 +206,13 @@ def _auth_headers(access_token: str) -> dict[str, str]:
 
 
 class TestSubmitAsset:
+    def test_asset_created_topic_is_mirrored_to_redis_stream(self, client):
+        _, _ = client
+        import services.tokenization.main as tokenization_main
+
+        handlers = tokenization_main._event_bus._handlers.get("asset.created", [])
+        assert handlers, "asset.created should be subscribed to at least one stream mirror handler"
+
     def test_seller_can_create_asset_with_pending_initial_status(self, client):
         app_client, settings = client
         fake_user = _make_fake_user(role="seller")


### PR DESCRIPTION
Ensure asset.created is mirrored to Redis streams and publish protocol-valid signed Nostr events including id/pubkey/sig so relays can accept messages while preserving non-blocking business flows.

Closes #45 